### PR TITLE
log opentelemetry errors to php error log

### DIFF
--- a/otel/Cargo.toml
+++ b/otel/Cargo.toml
@@ -22,6 +22,8 @@ once_cell = "1.20.3"
 anyhow = "1.0.95"
 chrono = "0.4.39"
 lazy_static = "1.5.0"
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"
 
 [dev-dependencies]
 phper-test = "0.14.1"

--- a/otel/src/logging.rs
+++ b/otel/src/logging.rs
@@ -1,0 +1,53 @@
+use phper::sys::{php_error_docref, E_WARNING, E_NOTICE};
+use tracing::{Event, Level, Subscriber, field::{Visit, Field}};
+use tracing_subscriber::{layer::Context, Layer};
+use std::ffi::CString;
+use std::fmt::{self, Write};
+
+/// A visitor that captures structured log fields into a string.
+struct LogVisitor {
+    message: String,
+}
+
+impl Visit for LogVisitor {
+    /// Handles string values in structured logging
+    fn record_str(&mut self, field: &Field, value: &str) {
+        write!(&mut self.message, " {}={}", field.name(), value).ok();
+    }
+
+    /// Handles non-string values (e.g., integers, structs) by formatting them as debug output
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        write!(&mut self.message, " {}={:?}", field.name(), value).ok();
+    }
+}
+
+/// A custom tracing layer that sends logs to the PHP error log.
+pub struct PhpErrorLogLayer;
+
+impl<S> Layer<S> for PhpErrorLogLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut message = format!("{}: {}", event.metadata().target(), event.metadata().name());
+
+        // Capture structured log fields
+        let mut visitor = LogVisitor { message: String::new() };
+        event.record(&mut visitor);
+        message.push_str(&visitor.message);
+
+        // Convert Rust string to C string for PHP
+        let c_message = CString::new(message).unwrap_or_else(|_| CString::new("Log message error").unwrap());
+
+        unsafe {
+            let error_type = match *event.metadata().level() {
+                Level::ERROR => E_WARNING,
+                Level::WARN => E_WARNING,
+                _ => E_NOTICE, // INFO and DEBUG as NOTICE
+            };
+
+            // Send to PHP error log
+            php_error_docref(std::ptr::null(), error_type.try_into().unwrap(), c_message.as_ptr());
+        }
+    }
+}

--- a/otel/tests/phpt/error-logging.phpt
+++ b/otel/tests/phpt/error-logging.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test internal errors logged
+--EXTENSIONS--
+otel
+--ENV--
+OTEL_EXPORTER_OTLP_ENDPOINT=http://does-not-exist:4318
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+--FILE--
+<?php
+use OpenTelemetry\API\Globals;
+
+Globals::tracerProvider()
+    ->getTracer('my_tracer')
+    ->spanBuilder('root')
+    ->startSpan()
+    ->end();
+?>
+--EXPECT--
+Warning: PHP Shutdown: opentelemetry_sdk: BatchSpanProcessor.ExportError message= name=BatchSpanProcessor.ExportError error=Operation failed: reqwest::Error { kind: Request, url: "http://does-not-exist:4318/v1/traces", source: hyper_util::client::legacy::Error(Connect, ConnectError("dns error", Custom { kind: Uncategorized, error: "failed to lookup address information: Temporary failure in name resolution" })) } in Unknown on line 0


### PR DESCRIPTION
Subscribe to opentelemetry-rust logging, and direct errors+warnings through php_error_docref
Errors can be displayed, sent to file etc per normal PHP configuration