### PR TITLE
implement .env file per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ As above
 ### `cgi-fcgi`
 As above
 
-## What works?
+## Features
 
 * Auto-instrumentation of userland (PHP8.0+) and internal (PHP8.2+) code, via zend_observer API (see `tests/auto/*`)
-* AUto-instrumentation of userland code via `zend_execute_ex` (PHP 7.x)
+* Auto-instrumentation of userland code via `zend_execute_ex` (PHP 7.x)
 * Start a span in RINIT, use `traceparent` headers, set HTTP response code in RSHUTDOWN
 * TracerProvider created in RINIT (so that child processes have a working instance)
 * Spans can be built through a SpanBuilder, some updates made (not all implemented yet), and `end()`ed
@@ -99,6 +99,7 @@ As above
 * Get SpanContext from a Span
 * Access "local root span"
 * `memory` exporter for testing
+* Support for shared hosting (ie one apache/fpm server with multiple sites), via `.env` files and `otel.dotenv.per_request` ini setting
 
 Basic usage:
 ```php
@@ -129,7 +130,6 @@ $scope->detach();
 
 ## What doesn't work or isn't implemented? (todo list)
 
-- read config from `.env` files (support multi-site installations that don't use vhosts?)
 - Context storage - otel-rust doesn't support storing non-simple values, and context keys are created at compile time.
 This will probably never work like opentelemetry-php.
 

--- a/otel/Cargo.toml
+++ b/otel/Cargo.toml
@@ -31,6 +31,7 @@ lazy_static = "1.5.0"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 dashmap = "6.1.0"
+dotenvy = "0.15.7"
 
 [build-dependencies]
 cargo_metadata = "0.19.2"

--- a/otel/src/auto/observer.rs
+++ b/otel/src/auto/observer.rs
@@ -31,6 +31,10 @@ pub fn init(plugin_manager: PluginManager) {
     logging::print_message("Observer::init".to_string());
     PLUGIN_MANAGER.get_or_init(|| plugin_manager);
     FUNCTION_OBSERVERS.get_or_init(|| RwLock::new(HashMap::new()));
+    unsafe {
+        sys::zend_observer_fcall_register(Some(observer_instrument));
+    }
+    logging::print_message("registered fcall handlers".to_string());
 }
 
 pub unsafe extern "C" fn observer_instrument(execute_data: *mut sys::zend_execute_data) -> sys::zend_observer_fcall_handlers {

--- a/otel/src/lib.rs
+++ b/otel/src/lib.rs
@@ -10,11 +10,6 @@ use crate::{
             text_map_propagator_interface::{make_text_map_propagator_interface},
         }
     },
-    request::{
-        get_server_var,
-        clear_request_env,
-        set_request_env,
-    },
     trace::{
         local_root_span::make_local_root_span_class,
         memory_exporter::make_memory_exporter_class,
@@ -38,7 +33,6 @@ use crate::{
     util::get_sapi_module_name,
     globals::{make_globals_class},
 };
-use std::fs;
 use phper::{
     ini::{ini_get, Policy},
     modules::Module,
@@ -52,7 +46,6 @@ use opentelemetry_sdk::{
 };
 use tokio::runtime::Runtime;
 use once_cell::sync::OnceCell;
-use std::collections::HashMap;
 
 pub mod context{
     pub mod context;
@@ -234,44 +227,7 @@ pub fn get_module() -> Module {
             logging::print_message("OpenTelemetry::RINIT::tokio runtime initialized".to_string());
         }
 
-        let per_request_dotenv = ini_get::<bool>("otel.dotenv.per_request");
-        if per_request_dotenv {
-            logging::print_message("OpenTelemetry::RINIT::Loading .env file".to_string());
-            if let Some(script_filename) = get_server_var("SCRIPT_FILENAME") {
-                if let Some(cwd) = std::path::Path::new(&script_filename).parent() {
-                    let env_path = cwd.join(".env");
-                    if fs::metadata(&env_path).is_ok() {
-                        let mut service_name = None;
-                        let mut resource_attributes = None;
-                        if let Ok(iter) = dotenvy::from_path_iter(&env_path) {
-                            for item in iter.flatten() {
-                                match item.0.as_str() {
-                                    "OTEL_SERVICE_NAME" => service_name = Some(item.1),
-                                    "OTEL_RESOURCE_ATTRIBUTES" => resource_attributes = Some(item.1),
-                                    _ => {}
-                                }
-                                if service_name.is_some() && resource_attributes.is_some() {
-                                    break;
-                                }
-                            }
-                            //now we _might_ have service name and resource attributes
-                            let mut env = HashMap::new();
-                            if let Some(service_name) = service_name {
-                                env.insert("OTEL_SERVICE_NAME".to_string(), service_name);
-                            }
-                            if let Some(resource_attributes) = resource_attributes {
-                                env.insert("OTEL_RESOURCE_ATTRIBUTES".to_string(), resource_attributes);
-                            }
-                            set_request_env(env);
-                        }
-                    } else {
-                        logging::print_message(format!("OpenTelemetry::RINIT::No .env file found in {:?}", cwd));
-                    }
-                }
-            } else {
-                logging::print_message("OpenTelemetry::RINIT::No SCRIPT_FILENAME found, skipping .env".to_string());
-            }
-        }
+        request::process_dotenv();
 
         tracer_provider::init_once();
         global::set_text_map_propagator(TraceContextPropagator::new());
@@ -283,7 +239,6 @@ pub fn get_module() -> Module {
         if is_disabled {
             return;
         }
-        clear_request_env();
         logging::print_message("OpenTelemetry::RSHUTDOWN".to_string());
         request::shutdown();
     });

--- a/otel/src/trace/tracer_provider.rs
+++ b/otel/src/trace/tracer_provider.rs
@@ -30,6 +30,7 @@ use opentelemetry_sdk::{
 };
 use once_cell::sync::Lazy;
 use crate::{
+    request,
     trace::tracer::TracerClass,
     util,
 };
@@ -40,16 +41,26 @@ const TRACER_PROVIDER_CLASS_NAME: &str = r"OpenTelemetry\API\Trace\TracerProvide
 
 pub type TracerProviderClass = StateClass<()>;
 
-static TRACER_PROVIDERS: Lazy<Mutex<HashMap<u32, Arc<SdkTracerProvider>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static TRACER_PROVIDERS: Lazy<Mutex<HashMap<(u32, String), Arc<SdkTracerProvider>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+//tracer provider per (service_name, resource_attributes) pair (from .env, if enabled)
+fn get_tracer_provider_key() -> (u32, String) {
+    let pid = process::id();
+    let env = request::get_request_env().unwrap_or_default();
+    let service_name = env.get("OTEL_SERVICE_NAME").cloned().unwrap_or_default();
+    let resource_attrs = env.get("OTEL_RESOURCE_ATTRIBUTES").cloned().unwrap_or_default();
+    let key = format!("{}:{}", service_name, resource_attrs);
+    (pid, key)
+}
 
 pub fn init_once() {
-    let pid = process::id();
+    let key = get_tracer_provider_key();
     let mut providers = TRACER_PROVIDERS.lock().unwrap();
-    if providers.contains_key(&pid) {
-        tracing::debug!("tracer provider already exists for pid {}", pid);
+    if providers.contains_key(&key) {
+        tracing::debug!("tracer provider already exists for key {:?}", key);
         return;
     }
-    tracing::debug!("creating tracer provider for pid {}", pid);
+    tracing::debug!("creating tracer provider for key {:?}", key);
     let use_simple_exporter = env::var("OTEL_SPAN_PROCESSOR").as_deref() == Ok("simple");
     tracing::debug!("SpanProcessor={}", if use_simple_exporter {"simple"} else {"batch"});
     if env::var("OTEL_TRACES_EXPORTER").as_deref() == Ok("none") {
@@ -58,9 +69,19 @@ pub fn init_once() {
             .with_resource(Resource::builder_empty().build())
             .with_sampler(AlwaysOff)
             .build();
-        providers.insert(pid, Arc::new(provider.clone()));
+        providers.insert(key, Arc::new(provider.clone()));
         return;
     }
+    // set some allowed environment variables from .env so that the builder will pick them up
+    if let Some(env_map) = request::get_request_env() {
+        if let Some(val) = env_map.get("OTEL_SERVICE_NAME") {
+            env::set_var("OTEL_SERVICE_NAME", val);
+        }
+        if let Some(val) = env_map.get("OTEL_RESOURCE_ATTRIBUTES") {
+            env::set_var("OTEL_RESOURCE_ATTRIBUTES", val);
+        }
+    }
+
     let resource = Resource::builder()
         .with_attribute(KeyValue::new("telemetry.sdk.language", "php"))
         .with_attribute(KeyValue::new("telemetry.sdk.name", "ext-otel"))
@@ -117,13 +138,14 @@ pub fn init_once() {
         .with_resource(resource)
         .build()
     );
-    providers.insert(pid, provider.clone());
+    providers.insert(key, provider.clone());
 }
 
 pub fn get_tracer_provider() -> Arc<SdkTracerProvider> {
     let pid = process::id();
     let providers = TRACER_PROVIDERS.lock().unwrap();
-    if let Some(provider) = providers.get(&pid) {
+    let key = get_tracer_provider_key();
+    if let Some(provider) = providers.get(&key) {
         return provider.clone();
     } else {
         tracing::error!("no tracer provider initialized for pid {}, using no-op", pid);
@@ -138,7 +160,8 @@ pub fn get_tracer_provider() -> Arc<SdkTracerProvider> {
 pub fn force_flush() {
     let pid = process::id();
     let providers = TRACER_PROVIDERS.lock().unwrap();
-    if let Some(provider) = providers.get(&pid) {
+    let key = get_tracer_provider_key();
+    if let Some(provider) = providers.get(&key) {
         tracing::info!("Flushing TracerProvider for pid {}", pid);
         match provider.force_flush() {
             Ok(_) => tracing::debug!("OpenTelemetry tracer provider flush success"),
@@ -152,11 +175,18 @@ pub fn force_flush() {
 pub fn shutdown() {
     let pid = process::id();
     let mut providers = TRACER_PROVIDERS.lock().unwrap();
-    if providers.contains_key(&pid) {
-        tracing::info!("Shutting down TracerProvider for pid {}", pid);
-        providers.remove(&pid);
+    let keys_to_remove: Vec<_> = providers
+        .keys()
+        .filter(|(k_pid, _)| *k_pid == pid)
+        .cloned()
+        .collect();
+    if !keys_to_remove.is_empty() {
+        tracing::info!("Shutting down all TracerProviders for pid {}", pid);
+        for key in keys_to_remove {
+            providers.remove(&key);
+        }
     } else {
-        tracing::info!("no tracer provider to shutdown for pid {}", pid);
+        tracing::info!("no tracer providers to shutdown for pid {}", pid);
     }
 }
 

--- a/otel/src/trace/tracer_provider.rs
+++ b/otel/src/trace/tracer_provider.rs
@@ -194,6 +194,7 @@ pub fn shutdown() {
     if !keys_to_remove.is_empty() {
         tracing::info!("Shutting down all TracerProviders for pid {}", pid);
         for key in keys_to_remove {
+            tracing::debug!("Shutting down TracerProvider for key {:?}", key);
             providers.remove(&key);
         }
     } else {

--- a/otel/tests/phpt/dotenv/dotenv-loaded-on-rinit.phpt
+++ b/otel/tests/phpt/dotenv/dotenv-loaded-on-rinit.phpt
@@ -1,0 +1,26 @@
+--TEST--
+dotenv support enabled
+--EXTENSIONS--
+otel
+--INI--
+otel.cli.enable=On
+otel.dotenv.per_request=On
+otel.log.level=debug
+--ENV--
+OTEL_TRACES_EXPORTER=console
+OTEL_SPAN_PROCESSOR=simple
+--FILE--
+<?php
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Trace\SpanExporter\Memory;
+Globals::tracerProvider()->getTracer('my_tracer')->spanBuilder('root')->startSpan()->end();
+?>
+--EXPECTF--
+%A
+[%s] [DEBUG] [pid=%d] [ThreadId(%d)] OpenTelemetry::RINIT::Loading .env file%A
+[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::trace::tracer_provider: event src/trace/tracer_provider.rs:%d message=creating tracer provider for key (%d, "from-dotenv:service.namespace=my-dotenv-service,service.version=0.1.0")
+%A
+Spans
+Resource%A
+	 ->  service.namespace=String(Owned("my-dotenv-service"))
+%A

--- a/otel/tests/phpt/dotenv/dotenv-loaded-on-rinit.phpt
+++ b/otel/tests/phpt/dotenv/dotenv-loaded-on-rinit.phpt
@@ -9,6 +9,8 @@ otel.log.level=debug
 --ENV--
 OTEL_TRACES_EXPORTER=console
 OTEL_SPAN_PROCESSOR=simple
+OTEL_SERVICE_NAME=do-not-use
+OTEL_RESOURCE_ATTRIBUTES=service.namespace=do-not-use
 --FILE--
 <?php
 use OpenTelemetry\API\Globals;
@@ -22,5 +24,4 @@ Globals::tracerProvider()->getTracer('my_tracer')->spanBuilder('root')->startSpa
 %A
 Spans
 Resource%A
-	 ->  service.namespace=String(Owned("my-dotenv-service"))
-%A
+	 ->  service.name=String(Owned("from-dotenv"))%A

--- a/otel/tests/phpt/dotenv/dotenv-loaded-on-rinit.phpt
+++ b/otel/tests/phpt/dotenv/dotenv-loaded-on-rinit.phpt
@@ -19,7 +19,6 @@ Globals::tracerProvider()->getTracer('my_tracer')->spanBuilder('root')->startSpa
 ?>
 --EXPECTF--
 %A
-[%s] [DEBUG] [pid=%d] [ThreadId(%d)] OpenTelemetry::RINIT::Loading .env file%A
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::trace::tracer_provider: event src/trace/tracer_provider.rs:%d message=creating tracer provider for key (%d, "from-dotenv:service.namespace=my-dotenv-service,service.version=0.1.0")
 %A
 Spans

--- a/otel/tests/phpt/dotenv/no-dotenv/dotenv-skipped-if-not-found.phpt
+++ b/otel/tests/phpt/dotenv/no-dotenv/dotenv-skipped-if-not-found.phpt
@@ -1,0 +1,26 @@
+--TEST--
+dotenv skipped if not found
+--EXTENSIONS--
+otel
+--INI--
+otel.cli.enable=On
+otel.dotenv.per_request=On
+otel.log.level=debug
+--ENV--
+OTEL_TRACES_EXPORTER=console
+OTEL_SPAN_PROCESSOR=simple
+--FILE--
+<?php
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Trace\SpanExporter\Memory;
+Globals::tracerProvider()->getTracer('my_tracer')->spanBuilder('root')->startSpan()->end();
+?>
+--EXPECTF--
+%A
+[%s] [DEBUG] [pid=%d] [ThreadId(%d)] OpenTelemetry::RINIT::Loading .env file%A
+[%s] [DEBUG] [pid=%d] [ThreadId(%d)] OpenTelemetry::RINIT::No .env file found in "/usr/src/myapp/tests/phpt/dotenv/no-dotenv"
+%A
+Spans
+Resource%A
+	 ->  service.name=String(Static("unknown_service"))
+%A

--- a/otel/tests/phpt/dotenv/no-dotenv/dotenv-skipped-if-not-found.phpt
+++ b/otel/tests/phpt/dotenv/no-dotenv/dotenv-skipped-if-not-found.phpt
@@ -17,8 +17,7 @@ Globals::tracerProvider()->getTracer('my_tracer')->spanBuilder('root')->startSpa
 ?>
 --EXPECTF--
 %A
-[%s] [DEBUG] [pid=%d] [ThreadId(%d)] OpenTelemetry::RINIT::Loading .env file%A
-[%s] [DEBUG] [pid=%d] [ThreadId(%d)] OpenTelemetry::RINIT::No .env file found in "/usr/src/myapp/tests/phpt/dotenv/no-dotenv"
+[%s] [WARN] [pid=%d] [ThreadId(%d)] otel::request: event src/request.rs:%d message=No .env file found in "/usr/src/myapp/tests/phpt/dotenv/no-dotenv"
 %A
 Spans
 Resource%A

--- a/otel/tests/phpt/phpinfo.phpt
+++ b/otel/tests/phpt/phpinfo.phpt
@@ -16,6 +16,7 @@ version => %s
 Directive => Local Value => Master Value
 otel.cli.create_root_span => 0 => 0
 otel.cli.enable => 0 => 0
+otel.dotenv.per_request => 0 => 0
 otel.log.file => %s => %s
 otel.log.level => error => error
 %A


### PR DESCRIPTION
To support multi-site setups (eg apache/fpm serving multiple sites out of sub-directories), add the capability to
read a .env file from the location of a request's SCRIPT_FILENAME. Pull OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES from this file if it exists, and use values to create/fetch a tracer provider. This allows
setting customised resource attributes, rather than having just one value set (or not) globally.