### PR TITLE
tidy, simplify sql parsing

### DIFF
--- a/otel/Cargo.toml
+++ b/otel/Cargo.toml
@@ -33,7 +33,7 @@ tracing-subscriber = "0.3.19"
 dotenvy = "0.15.7"
 hostname = "0.4.1"
 lazy_static = "1.5.0"
-sqlparser = "0.58.0"
+regex = "1.11.1"
 
 [build-dependencies]
 cargo_metadata = "0.21.0"

--- a/otel/src/auto/execute.rs
+++ b/otel/src/auto/execute.rs
@@ -3,7 +3,6 @@ use phper::{
     sys,
     values::{ExecuteData,ZVal},
 };
-use std::ptr::null_mut;
 use crate::{
     auto::{
         execute_data::{
@@ -18,6 +17,7 @@ use crate::{
 };
 use std::{
     collections::HashMap,
+    ptr::null_mut,
 };
 
 thread_local! {

--- a/otel/src/auto/execute_data.rs
+++ b/otel/src/auto/execute_data.rs
@@ -2,10 +2,8 @@ use phper::{
     eg,
     objects::ZObj,
     sys,
-    strings::{ZStr},
-    values::{
-        ExecuteData,
-    }
+    strings::ZStr,
+    values::ExecuteData,
 };
 use opentelemetry::{
     KeyValue,

--- a/otel/src/auto/plugin_manager.rs
+++ b/otel/src/auto/plugin_manager.rs
@@ -13,7 +13,7 @@ use phper::{
     classes::ClassEntry,
     functions::ZFunc,
     ini::ini_get,
-    strings::{ZString},
+    strings::ZString,
     values::ExecuteData,
 };
 use once_cell::sync::OnceCell;

--- a/otel/src/auto/plugins/laminas.rs
+++ b/otel/src/auto/plugins/laminas.rs
@@ -5,9 +5,6 @@ use crate::{
         utils,
     },
     config::trace_attributes,
-};
-use crate::{
-    auto::utils::record_exception,
     context::storage::{take_guard},
     error::StringError,
     request::get_request_details,
@@ -316,7 +313,7 @@ impl LaminasDbConnectHandler {
         exception: Option<&mut ZObj>
     ) {
         if let Some(exception) = exception {
-            record_exception(&opentelemetry::Context::current(), exception);
+            utils::record_exception(&opentelemetry::Context::current(), exception);
         }
     }
 }
@@ -348,7 +345,7 @@ impl LaminasSqlPrepareHandler {
         tracing::debug!("Auto::Laminas::post (Sql::prepare) - post_callback called");
 
         if let Some(exception) = exception {
-            record_exception(&opentelemetry::Context::current(), exception);
+            utils::record_exception(&opentelemetry::Context::current(), exception);
         }
         // return value may be optimized away in php 7.x, if so use the second parameter (which is mutated)
         let statement_container_zval: &mut ZVal = if retval.get_type_info() == phper::types::TypeInfo::NULL {
@@ -417,7 +414,7 @@ impl LaminasStatementPrepareHandler {
         tracing::debug!("Auto::Laminas::post (Statement::prepare) - post_callback called");
 
         if let Some(exception) = exception {
-            record_exception(&opentelemetry::Context::current(), exception);
+            utils::record_exception(&opentelemetry::Context::current(), exception);
         }
 
         // Get the first parameter as a string, if present
@@ -501,7 +498,7 @@ impl LaminasStatementExecuteHandler {
         exception: Option<&mut ZObj>
     ) {
         if let Some(exception) = exception {
-            record_exception(&opentelemetry::Context::current(), exception);
+            utils::record_exception(&opentelemetry::Context::current(), exception);
         }
         take_guard(exec_data);
     }
@@ -551,7 +548,7 @@ impl LaminasConnectionExecuteHandler {
     ) {
         tracing::debug!("Auto::Laminas::post (Connection::execute) - post_callback called");
         if let Some(exception) = exception {
-            record_exception(&opentelemetry::Context::current(), exception);
+            utils::record_exception(&opentelemetry::Context::current(), exception);
         }
         take_guard(exec_data);
     }

--- a/otel/src/auto/plugins/psr18.rs
+++ b/otel/src/auto/plugins/psr18.rs
@@ -1,18 +1,22 @@
-use crate::auto::{
-    execute_data::{get_default_attributes},
-    plugin::{Handler, HandlerList, HandlerSlice, HandlerCallbacks, Plugin},
-    utils::{start_and_activate_span, record_exception},
+use crate::{
+    auto::{
+        execute_data::{get_default_attributes},
+        plugin::{Handler, HandlerList, HandlerSlice, HandlerCallbacks, Plugin},
+        utils::{start_and_activate_span, record_exception},
+    },
+    context::storage::{take_guard},
+    tracer_provider,
 };
-use crate::tracer_provider;
-use crate::context::storage::{take_guard};
 use opentelemetry::{
     KeyValue,
     Context,
     global,
-    trace::{SpanKind},
+    trace::{
+        SpanKind,
+        TraceContextExt,
+        TracerProvider,
+    },
 };
-use opentelemetry::trace::TraceContextExt;
-use opentelemetry::trace::TracerProvider;
 use opentelemetry_semantic_conventions as SemConv;
 use std::{
     sync::Arc,

--- a/otel/src/auto/plugins/test.rs
+++ b/otel/src/auto/plugins/test.rs
@@ -1,27 +1,28 @@
 // A test plugin which implements three handlers:
 // - DemoHandler: observes a handful of classes and functions with a pre and post callback
 // - DemoFunctionHandler: observes a specific function with a different pre and post callback
-use crate::auto::{
-    execute_data::{get_default_attributes, get_fqn},
-    plugin::{Handler, HandlerList, HandlerSlice, HandlerCallbacks, Plugin},
-    utils::record_exception,
-};
-use opentelemetry::{
-    KeyValue,
-    trace::{Tracer, TracerProvider},
-};
 use crate::{
+    auto::{
+        execute_data::{get_default_attributes, get_fqn},
+        plugin::{Handler, HandlerList, HandlerSlice, HandlerCallbacks, Plugin},
+        utils::record_exception,
+    },
     context::storage::{store_guard, take_guard},
     tracer_provider,
+};
+use opentelemetry::{
+    Context,
+    KeyValue,
+    trace::{
+        Tracer,
+        TraceContextExt,
+        TracerProvider,
+    },
 };
 use std::sync::Arc;
 use phper::{
     values::{ExecuteData, ZVal},
     objects::ZObj,
-};
-use opentelemetry::{
-    Context,
-    trace::TraceContextExt,
 };
 
 pub struct TestPlugin {

--- a/otel/src/auto/plugins/zf1.rs
+++ b/otel/src/auto/plugins/zf1.rs
@@ -1,13 +1,10 @@
 use crate::{
     auto::{
+        execute_data::get_default_attributes,
         plugin::{Handler, HandlerList, HandlerSlice, HandlerCallbacks, Plugin},
         utils,
     },
     config::trace_attributes,
-};
-use crate::{
-    auto::execute_data::get_default_attributes,
-    auto::utils::record_exception,
     context::storage::{take_guard},
     trace::local_root_span::get_local_root_span_context,
     tracer_provider,
@@ -284,7 +281,7 @@ impl Zf1AdapterPrepareHandler {
         exception: Option<&mut ZObj>
     ) {
         if let Some(exception) = exception {
-            record_exception(&opentelemetry::Context::current(), exception);
+            utils::record_exception(&opentelemetry::Context::current(), exception);
         } else {
             //prepared statement is the return value
             let statement_obj = retval.as_mut_z_obj().expect("Expected a ZObj for prepared statement");
@@ -358,7 +355,7 @@ impl Zf1StatementExecuteHandler {
         exception: Option<&mut ZObj>
     ) {
         if let Some(exception) = exception {
-            record_exception(&opentelemetry::Context::current(), exception);
+            utils::record_exception(&opentelemetry::Context::current(), exception);
         }
         take_guard(exec_data);
     }

--- a/otel/src/error.rs
+++ b/otel/src/error.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 use opentelemetry::KeyValue;
-use phper::objects::ZObj;
-use phper::values::{ZVal};
+use phper::{
+    objects::ZObj,
+    values::ZVal,
+};
 
 /// A custom error type that wraps a String and implements the Display, Debug, and Error traits.
 /// Used for recording string-based errors on a Span.

--- a/otel/src/globals.rs
+++ b/otel/src/globals.rs
@@ -3,8 +3,8 @@ use phper::{
         ClassEntity,
         Visibility,
     },
-    functions::{ReturnType},
-    types::{ReturnTypeHint},
+    functions::ReturnType,
+    types::ReturnTypeHint,
 };
 use crate::trace::{
     propagation::trace_context_propagator::TraceContextPropagatorClass,


### PR DESCRIPTION
This pull request refactors imports and improves SQL span name extraction in the OpenTelemetry PHP auto-instrumentation codebase. The most significant change is the replacement of the `sqlparser` dependency with a custom regex-based approach for extracting SQL operation names, which simplifies and speeds up the code. Additionally, the PR standardizes import formatting across multiple files and ensures consistent usage of the `record_exception` utility function.

**SQL Span Name Extraction Improvements**
* Replaced the `sqlparser` dependency with custom regular expressions for SQL span name extraction in `otel/src/auto/utils.rs`, simplifying the logic and improving performance. The `sqlparser` crate was removed from `otel/Cargo.toml` and replaced with `regex`. [[1]](diffhunk://#diff-9919b6388d49e329822ac4936705e5cb037c1cc8695800b8433927023327370fL36-R36) [[2]](diffhunk://#diff-93580f1d0c54070190c0d4dedc028d92f509e8219506580fe6532a01eca71f2fL1-R41)

**Import and Module Refactoring**
* Standardized and reorganized imports in multiple files (`execute.rs`, `execute_data.rs`, `plugin_manager.rs`, `plugins/laminas.rs`, `plugins/psr18.rs`, `plugins/test.rs`, `plugins/zf1.rs`, `error.rs`, `globals.rs`) for clarity and consistency, including grouping and ordering. [[1]](diffhunk://#diff-c11ae1a792baab3b4f5f4cd50989de66c0e171cba946541325aa304d4804bc66L6) [[2]](diffhunk://#diff-c11ae1a792baab3b4f5f4cd50989de66c0e171cba946541325aa304d4804bc66R20) [[3]](diffhunk://#diff-60bd3c6a28b0289099121f7856aae931c6d3ffb542cc4c44696cdbc7a9db7a4aL5-R6) [[4]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L16-R16) [[5]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL8-L10) [[6]](diffhunk://#diff-a5a599cad14cd7b73890269f75a753c930cc281330e0dde65f5f0574b6b5df1fL1-L15) [[7]](diffhunk://#diff-79f640991c11f5eb66f95f9c20e672c5901e88d588311c982a36a97fee5c8cdcL4-L25) [[8]](diffhunk://#diff-84e8a5799aa85d4d68929b67c85c63c360bd9b97d20f3dcced68670ba3510eadR3-L10) [[9]](diffhunk://#diff-63514a5cb98c9c0e9556f0720cc177afa2aa377ddfff51949c4b5798d8f98018L3-R6) [[10]](diffhunk://#diff-5b8611369a1e7c8985046c0b9a6cf916fc4ee5d387dfeddbe14912d5bee963e0L6-R7)

**Exception Recording Consistency**
* Updated all plugin handler implementations to reference `record_exception` via the `utils` module for consistency and clarity. [[1]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL319-R316) [[2]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL351-R348) [[3]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL420-R417) [[4]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL504-R501) [[5]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL554-R551) [[6]](diffhunk://#diff-84e8a5799aa85d4d68929b67c85c63c360bd9b97d20f3dcced68670ba3510eadL287-R284) [[7]](diffhunk://#diff-84e8a5799aa85d4d68929b67c85c63c360bd9b97d20f3dcced68670ba3510eadL361-R358)

These changes streamline the codebase, reduce dependencies, and improve maintainability and performance.