### PR TITLE
refactoring

### DIFF
--- a/otel/Makefile
+++ b/otel/Makefile
@@ -39,7 +39,7 @@ update:
 clean-build-test: clean test-all
 test: build-test
 	@echo "Running all tests..."
-	php run-tests.php -q -j4 --show-diff tests/phpt/
+	php run-tests.php -q --show-diff tests/phpt/
 test-all: build-test
 	@echo "Running functional tests..."
 	php run-tests.php -q tests/
@@ -48,7 +48,7 @@ test-export: build-test
 	php run-tests.php -q --show-diff tests/otlp/
 test-auto: build-test
 	@echo "Running auto-instrumentation tests..."
-	php run-tests.php -q -j4 --show-diff tests/auto/
+	php run-tests.php -q --show-diff tests/auto/
 test-http: build-test
 	@echo "Running HTTP tests with built-in webserver..."
 	php run-tests.php -q --show-diff tests/http/

--- a/otel/Makefile
+++ b/otel/Makefile
@@ -29,15 +29,17 @@ clean:
 	rm -rf configure* config.h.* libtool Makefile.* run-tests.php build/ autom4te.cache/
 	rm -rf tests/auto/laminas/vendor/* tests/auto/laminas/composer.lock
 	rm -rf tests/auto/zf1/vendor/* tests/auto/zf1/composer.lock
+	rm -rf tests/auto/psr18/vendor/* tests/auto/psr18/composer.lock
 update:
 	@echo "Updating composer dependencies..."
 	(cd tests/auto/laminas && composer update --no-dev)
 	(cd tests/auto/zf1 && composer update --no-dev)
+	(cd tests/auto/psr18 && composer update --no-dev)
 	@echo "✅ Composer dependencies updated"
 clean-build-test: clean test-all
 test: build-test
 	@echo "Running all tests..."
-	php run-tests.php -q --show-diff tests/phpt/
+	php run-tests.php -q -j4 --show-diff tests/phpt/
 test-all: build-test
 	@echo "Running functional tests..."
 	php run-tests.php -q tests/
@@ -46,7 +48,7 @@ test-export: build-test
 	php run-tests.php -q --show-diff tests/otlp/
 test-auto: build-test
 	@echo "Running auto-instrumentation tests..."
-	php run-tests.php -q --show-diff tests/auto/
+	php run-tests.php -q -j4 --show-diff tests/auto/
 test-http: build-test
 	@echo "Running HTTP tests with built-in webserver..."
 	php run-tests.php -q --show-diff tests/http/

--- a/otel/src/context/context.rs
+++ b/otel/src/context/context.rs
@@ -49,9 +49,7 @@ pub fn build_context_class(
 
     class
         .add_method("__destruct", Visibility::Public, |this, _| {
-            let context_id = this.get_property("context_id")
-                .as_long()
-                .and_then(|id| if id > 0 { Some(id as u64) } else { None });
+            let context_id = get_instance_id(this);
             debug!("Context::__destruct for context_id = {:?}", context_id);
             if context_id.is_some() {
                 storage::maybe_remove_context_instance(context_id);
@@ -126,4 +124,11 @@ pub fn build_context_class(
             Ok::<_, phper::Error>(object)
         });
 
+}
+
+/// Get context instance id from a PHP object
+pub fn get_instance_id(obj: &phper::objects::ZObj) -> Option<u64> {
+    obj.get_property("context_id")
+        .as_long()
+        .and_then(|id| if id > 0 { Some(id as u64) } else { None })
 }

--- a/otel/src/context/scope.rs
+++ b/otel/src/context/scope.rs
@@ -1,6 +1,9 @@
 use crate::{
     context::{
-        context::ContextClassEntity,
+        context::{
+            get_instance_id,
+            ContextClassEntity,
+        },
         storage,
     },
     trace::local_root_span,
@@ -43,9 +46,7 @@ pub fn build_scope_class(
 
     class
         .add_method("detach", Visibility::Public, |this, _| -> phper::Result<()> {
-            let instance_id = this.get_property("context_id")
-                .as_long()
-                .and_then(|id| if id > 0 { Some(id as u64) } else { None });
+            let instance_id = get_instance_id(this);
             if instance_id.is_some() {
                 storage::detach_context(instance_id);
                 local_root_span::maybe_remove_local_root_span(instance_id);
@@ -56,9 +57,7 @@ pub fn build_scope_class(
 
     class
         .add_method("context", Visibility::Public, move |this,_| {
-            let instance_id = this.get_property("context_id")
-                .as_long()
-                .and_then(|id| if id > 0 { Some(id as u64) } else { None });
+            let instance_id = get_instance_id(this);
             let ctx = storage::get_context_instance(instance_id);
             let mut object = context_ce.init_object()?;
             *object.as_mut_state() = ctx;

--- a/otel/src/context/storage.rs
+++ b/otel/src/context/storage.rs
@@ -163,7 +163,6 @@ pub fn current_context_instance_id() -> Option<u64> {
     })
 }
 
-//TODO use Option<u64> instead of 0 having special meaning
 fn new_instance_id() -> u64 {
     INSTANCE_COUNTER.fetch_add(1, Ordering::Relaxed)
 }
@@ -190,7 +189,6 @@ pub fn build_storage_class(
 
     class
         .add_static_method("current", Visibility::Public, move |_| {
-            //TODO current from storage's perspective or opentelemetry-rust's?
             let context = Arc::new(Context::current());
             let mut object = context_ce.clone().init_object()?;
             *object.as_mut_state() = Some(context);

--- a/otel/src/context/storage.rs
+++ b/otel/src/context/storage.rs
@@ -39,34 +39,37 @@ static INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 pub fn current_context() -> Arc<Context> {
     current_context_instance_id()
-        .and_then(get_context_instance)
+        .and_then(|id| get_context_instance(Some(id)))
         .unwrap_or_else(|| Arc::new(Context::current()))
 }
 
-pub fn resolve_context(instance_id: u64) -> Arc<Context> {
-    if instance_id == 0 {
-        Arc::new(Context::current())
-    } else {
-        get_context_instance(instance_id).expect("context not found")
+pub fn resolve_context(instance_id: Option<u64>) -> Arc<Context> {
+    match instance_id {
+        Some(id) => get_context_instance(Some(id)).expect("context not found"),
+        None => Arc::new(Context::current()),
     }
 }
 
-pub fn get_context_instance(instance_id: u64) -> Option<Arc<Context>> {
-    debug!("Getting context instance {}", instance_id);
-    CONTEXT_STORAGE.with(|storage| {
-        let maybe_context = storage.borrow().get(&instance_id).cloned();
-        if let Some(ref ctx) = maybe_context {
-            debug!(
-                "Cloned context instance {} (ref count after clone = {})",
-                instance_id,
-                Arc::strong_count(ctx)
-            );
-        }
-        maybe_context
-    })
+pub fn get_context_instance(instance_id: Option<u64>) -> Option<Arc<Context>> {
+    if let Some(id) = instance_id {
+        debug!("Getting context instance {}", id);
+        CONTEXT_STORAGE.with(|storage| {
+            let maybe_context = storage.borrow().get(&id).cloned();
+            if let Some(ref ctx) = maybe_context {
+                debug!(
+                    "Cloned context instance {} (ref count after clone = {})",
+                    id,
+                    Arc::strong_count(ctx)
+                );
+            }
+            maybe_context
+        })
+    } else {
+        None
+    }
 }
 
-pub fn store_context_instance(context: Arc<Context>) -> u64 {
+pub fn store_context_instance(context: Arc<Context>) -> Option<u64> {
     let instance_id = new_instance_id();
     let count = Arc::strong_count(&context);
     debug!(
@@ -77,38 +80,40 @@ pub fn store_context_instance(context: Arc<Context>) -> u64 {
         storage.borrow_mut().insert(instance_id, context)
     });
 
-    instance_id
+    Some(instance_id)
 }
 
 /// remove context instance if it's not stored in GUARD_STACK
-pub fn maybe_remove_context_instance(instance_id: u64) {
-    debug!("Maybe remove context for instance {}", instance_id);
-    CONTEXT_STORAGE.with(|storage| {
-        let mut map = storage.borrow_mut();
-        match map.get(&instance_id) {
-            Some(context) => {
-                let count = Arc::strong_count(context);
-                if count == 1 { //the only reference is in CONTEXT_STORAGE
+pub fn maybe_remove_context_instance(instance_id: Option<u64>) {
+    if let Some(id) = instance_id {
+        debug!("Maybe remove context for instance {}", id);
+        CONTEXT_STORAGE.with(|storage| {
+            let mut map = storage.borrow_mut();
+            match map.get(&id) {
+                Some(context) => {
+                    let count = Arc::strong_count(context);
+                    if count == 1 { //the only reference is in CONTEXT_STORAGE
+                        debug!(
+                            "Removing context instance {} (ref count = 1, no external holders)",
+                            id
+                        );
+                        map.remove(&id);
+                    } else {
+                        debug!(
+                            "Cannot remove context instance {} (ref count = {}, still in use)",
+                            id, count
+                        );
+                    }
+                }
+                None => {
                     debug!(
-                        "Removing context instance {} (ref count = 1, no external holders)",
-                        instance_id
-                    );
-                    map.remove(&instance_id);
-                } else {
-                    debug!(
-                        "Cannot remove context instance {} (ref count = {}, still in use)",
-                        instance_id, count
+                        "Context instance {} not found in CONTEXT_STORAGE, already removed?",
+                        id
                     );
                 }
             }
-            None => {
-                debug!(
-                    "Context instance {} not found in CONTEXT_STORAGE, already removed?",
-                    instance_id
-                );
-            }
-        }
-    });
+        });
+    }
 }
 
 pub fn remove_context_instance(instance_id: u64) {
@@ -116,34 +121,40 @@ pub fn remove_context_instance(instance_id: u64) {
     CONTEXT_STORAGE.with(|storage| storage.borrow_mut().remove(&instance_id));
 }
 
-pub fn attach_context(instance_id: u64) -> Result<(), &'static str> {
-    debug!("Attaching context instance {}", instance_id);
-    let context = get_context_instance(instance_id).ok_or("Context not found")?;
-    let context_guard = Arc::clone(&context);
-    debug!(
-        "Before attach: context instance {} has ref count = {}",
-        instance_id,
-        Arc::strong_count(&context)
-    );
-    let guard = (*context_guard).clone().attach();
-    GUARD_STACK.with(|stack| {
-        stack.borrow_mut().push((guard, instance_id));
-    });
-    Ok(())
+pub fn attach_context(instance_id: Option<u64>) -> Result<(), &'static str> {
+    match instance_id {
+        Some(id) => {
+            debug!("Attaching context instance {}", id);
+            let context = get_context_instance(Some(id)).ok_or("Context not found")?;
+            let context_guard = Arc::clone(&context);
+            debug!(
+                "Before attach: context instance {} has ref count = {}",
+                id,
+                Arc::strong_count(&context)
+            );
+            let guard = (*context_guard).clone().attach();
+            GUARD_STACK.with(|stack| {
+                stack.borrow_mut().push((guard, id));
+            });
+            Ok(())
+        }
+        None => Err("No context id provided"),
+    }
 }
 
-pub fn detach_context(instance_id: u64) {
-    debug!("Detaching context instance {}", instance_id);
-    GUARD_STACK.with(|stack| {
-        stack.borrow_mut().pop().map(|(_guard, id)| {
-            if id == instance_id {
-                maybe_remove_context_instance(id);
-            } else {
-                //context detach out of order = is an error
-                debug!("Not detaching context instance {}, is not top-most", instance_id);
-            }
+pub fn detach_context(instance_id: Option<u64>) {
+    if let Some(id) = instance_id {
+        debug!("Detaching context instance {}", id);
+        GUARD_STACK.with(|stack| {
+            stack.borrow_mut().pop().map(|(_guard, stack_id)| {
+                if stack_id == id {
+                    maybe_remove_context_instance(Some(stack_id));
+                } else {
+                    debug!("Not detaching context instance {}, is not top-most", id);
+                }
+            });
         });
-    });
+    }
 }
 
 pub fn current_context_instance_id() -> Option<u64> {
@@ -191,11 +202,14 @@ pub fn build_storage_class(
     class
         .add_method("attach", Visibility::Public, move |_, arguments| {
             let context_obj: &mut ZObj = arguments[0].expect_mut_z_obj()?;
-            let instance_id = context_obj.get_property("context_id").as_long().unwrap_or(0);
-            attach_context(instance_id as u64).map_err(phper::Error::boxed)?;
+            let instance_id = context_obj.get_property("context_id").as_long();
+            let opt_instance_id = instance_id.map(|id| id as u64);
+            attach_context(opt_instance_id).map_err(phper::Error::boxed)?;
 
             let mut object = scope_ce_attach.init_object()?;
-            object.set_property("context_id", instance_id as i64);
+            if let Some(id) = opt_instance_id {
+                object.set_property("context_id", id as i64);
+            }
             Ok::<_, phper::Error>(object)
         })
         .argument(Argument::new("context").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(r"OpenTelemetry\Context\ContextInterface"))))

--- a/otel/src/lib.rs
+++ b/otel/src/lib.rs
@@ -102,7 +102,6 @@ pub mod auto{
         pub mod zf1;
     }
 }
-use crate::auto::plugin_manager::PluginManager;
 
 include!(concat!(env!("OUT_DIR"), "/package_versions.rs"));
 
@@ -190,16 +189,16 @@ pub fn get_module() -> Module {
 
         let auto_enabled = ini_get::<bool>(config::ini::OTEL_AUTO_ENABLED);
         if auto_enabled {
-            let plugin_manager = PluginManager::new();
-            crate::auto::plugin_manager::set_global(plugin_manager);
+            let plugin_manager = auto::plugin_manager::PluginManager::new();
+            auto::plugin_manager::set_global(plugin_manager);
 
             #[cfg(otel_observer_supported)]
             {
-                crate::auto::observer::init();
+                auto::observer::init();
             }
             #[cfg(otel_observer_not_supported)]
             {
-                crate::auto::execute::init();
+                auto::execute::init();
             }
         } else {
             tracing::debug!("OpenTelemetry::MINIT auto-instrumentation disabled");
@@ -239,7 +238,7 @@ pub fn get_module() -> Module {
         tracing::debug!("OpenTelemetry::RSHUTDOWN");
         request::shutdown();
         //call plugin manager request_shutdown
-        if let Some(plugin_manager) = crate::auto::plugin_manager::get_global() {
+        if let Some(plugin_manager) = auto::plugin_manager::get_global() {
             let mut pm = plugin_manager.write().expect("Failed to acquire write lock");
             pm.request_shutdown();
         }

--- a/otel/src/request.rs
+++ b/otel/src/request.rs
@@ -216,7 +216,7 @@ pub fn init() {
     let ctx = Context::current_with_span(span);
     let context_id = storage::store_context_instance(Arc::new(ctx.clone()));
     OTEL_CONTEXT_ID.with(|cell| {
-        *cell.borrow_mut() = Some(context_id);
+        *cell.borrow_mut() = context_id;
     });
     if is_local_root {
         tracing::debug!("RINIT::is_local_root: {}", is_local_root);
@@ -241,7 +241,7 @@ pub fn shutdown() {
         let context_id = context_id.unwrap();
         let is_http_request = get_sapi_module_name() != "cli";
         tracing::debug!("RSHUTDOWN::auto-closing root span...");
-        let ctx = storage::get_context_instance(context_id);
+        let ctx = storage::get_context_instance(Some(context_id));
         if ctx.is_none() {
             tracing::warn!("RSHUTDOWN::no context found for id {}", context_id);
             return;
@@ -270,7 +270,7 @@ pub fn shutdown() {
             span.end();
             tracing::debug!("RSHUTDOWN::removing context: {}", context_id);
             drop(ctx);
-            storage::maybe_remove_context_instance(context_id);
+            storage::maybe_remove_context_instance(Some(context_id));
         }
 
         OTEL_REQUEST_GUARD.with(|slot| {

--- a/otel/src/request.rs
+++ b/otel/src/request.rs
@@ -222,7 +222,6 @@ pub fn init() {
         tracing::debug!("RINIT::is_local_root: {}", is_local_root);
         local_root_span::store_local_root_span(context_id);
     }
-    //TODO use span::storeInContext logic
     let guard = ctx.attach();
 
     OTEL_REQUEST_GUARD.with(|slot| {

--- a/otel/src/trace/propagation/trace_context_propagator.rs
+++ b/otel/src/trace/propagation/trace_context_propagator.rs
@@ -7,9 +7,11 @@ use phper::{
 use std::sync::Arc;
 use std::convert::Infallible;
 use crate::context::{
-    context::ContextClassEntity,
+    context::{
+        get_instance_id,
+        ContextClassEntity,
+    },
     storage,
-
 };
 
 pub type TraceContextPropagatorClass = StateClass<()>;
@@ -32,10 +34,7 @@ pub fn make_trace_context_propagator_class(
         .add_method("inject", Visibility::Public, |_, arguments| -> phper::Result<()> {
             // Context (optional, default to Context::current)
             let context_obj = arguments[2].expect_mut_z_obj()?;
-            let context_id = context_obj
-                .get_property("context_id")
-                .as_long()
-                .and_then(|id| if id > 0 { Some(id as u64) } else { None });
+            let context_id = get_instance_id(context_obj);
             tracing::debug!("inject() using context_id = {:?}", context_id);
 
             let context = storage::get_context_instance(context_id);

--- a/otel/src/trace/span.rs
+++ b/otel/src/trace/span.rs
@@ -23,7 +23,10 @@ use opentelemetry::{
 use opentelemetry_sdk::trace::Span as SdkSpan;
 use crate::{
     context::{
-        context::ContextClass,
+        context::{
+            get_instance_id,
+            ContextClass,
+        },
         scope::ScopeClass,
         storage,
     },
@@ -282,9 +285,7 @@ pub fn make_span_class(
             let span = this.as_mut_state().take().expect("No span stored!");
 
             let context_obj: &mut ZObj = arguments[0].expect_mut_z_obj()?;
-            let context_id = context_obj.get_property("context_id")
-                .as_long()
-                .and_then(|id| if id > 0 { Some(id as u64) } else { None });
+            let context_id = get_instance_id(context_obj);
             // Always go through storage — handles context_id = None as Context::current()
             let context = storage::resolve_context(context_id);
             let arc_ctx = Arc::new(context.with_span(span));
@@ -310,10 +311,4 @@ pub fn make_span_class(
         });
 
     class
-}
-
-fn get_instance_id(this: &phper::objects::ZObj) -> Option<u64> {
-    this.get_property("context_id")
-        .as_long()
-        .and_then(|id| if id > 0 { Some(id as u64) } else { None })
 }

--- a/otel/src/trace/span.rs
+++ b/otel/src/trace/span.rs
@@ -256,7 +256,6 @@ pub fn make_span_class(
             }
         });
 
-    //TODO should activate() use storeInContext()
     class
         .add_method("activate", Visibility::Public, {
             let scope_ce = scope_class.clone();
@@ -301,7 +300,6 @@ pub fn make_span_class(
     let span_class_clone = class.bound_class();
     class
         .add_static_method("fromContext", Visibility::Public, move |arguments| {
-            //todo could this become a macro?? better, a generic macro?
             let context_obj: &mut ZObj = arguments[0].expect_mut_z_obj()?;
             let instance_id = context_obj.get_property("context_id").as_long().unwrap_or(0);
             let mut object = span_class_clone.init_object()?;

--- a/otel/src/trace/span_builder.rs
+++ b/otel/src/trace/span_builder.rs
@@ -116,7 +116,7 @@ pub fn make_span_builder_class(span_class: SpanClass) -> ClassEntity<SpanBuilder
             let span_builder = state.span_builder.as_ref().expect("SpanBuilder not set");
             let tracer = state.tracer.as_ref().expect("Tracer not set");
             let parent_context = if state.parent_context_id > 0 {
-                storage::get_context_instance(state.parent_context_id)
+                storage::get_context_instance(Some(state.parent_context_id))
                     .map(|ctx| {
                         tracing::debug!(
                             "SpanBuilder::Using parent context {} (ref count = {})",

--- a/otel/src/trace/tracer_provider.rs
+++ b/otel/src/trace/tracer_provider.rs
@@ -35,10 +35,12 @@ use once_cell::sync::{
 use tokio::runtime::Runtime;
 use crate::{
     request,
-    trace::tracer::TracerClass,
+    trace::{
+        memory_exporter::MEMORY_EXPORTER,
+        tracer::TracerClass
+    },
     util,
 };
-use crate::trace::memory_exporter::MEMORY_EXPORTER;
 
 const TRACER_PROVIDER_CLASS_NAME: &str = r"OpenTelemetry\API\Trace\TracerProvider";
 
@@ -130,7 +132,7 @@ pub fn init_once() {
                 TOKIO_RUNTIME.set(runtime).expect("Tokio runtime already set");
                 tracing::debug!("tokio runtime initialized");
             }
-            let runtime = get_runtime();
+            let runtime = TOKIO_RUNTIME.get().expect("Tokio runtime not initialized");
             let exporter = runtime.block_on(async {
                 OtlpSpanExporter::builder()
                     .with_tonic()
@@ -149,10 +151,6 @@ pub fn init_once() {
         .build()
     );
     providers.insert(key, provider.clone());
-}
-
-fn get_runtime() -> &'static Runtime {
-    TOKIO_RUNTIME.get().expect("Tokio runtime not initialized")
 }
 
 pub fn get_tracer_provider() -> Arc<SdkTracerProvider> {

--- a/otel/tests/phpt/context/context-cleanup-span.phpt
+++ b/otel/tests/phpt/context/context-cleanup-span.phpt
@@ -60,7 +60,7 @@ string(19) "pre: storage attach"
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Getting context instance 1
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Cloned context instance 1 (ref count after clone = 3)
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Before attach: context instance 1 has ref count = 4
-[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Context::__destruct for context_id = 1
+[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Context::__destruct for context_id = Some(1)
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Maybe remove context for instance 1
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Cannot remove context instance 1 (ref count = 2, still in use)
 string(20) "post: storage attach"
@@ -72,7 +72,7 @@ string(18) "post: detach scope"
 string(32) "pre: get span from scope context"
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Getting context instance 1
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Cloned context instance 1 (ref count after clone = 2)
-[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Context::__destruct for context_id = 1
+[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Context::__destruct for context_id = Some(1)
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Maybe remove context for instance 1
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Cannot remove context instance 1 (ref count = 2, still in use)
 string(33) "post: get span from scope context"
@@ -85,6 +85,6 @@ string(13) "pre: span end"
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Maybe remove context for instance 1
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Removing context instance 1 (ref count = 1, no external holders)
 string(14) "post: span end"
-[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Context::__destruct for context_id = 0
+[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Context::__destruct for context_id = None
 %A
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::request: event src/request.rs:%d message=RSHUTDOWN::CONTEXT_STORAGE is empty :)%A

--- a/otel/tests/phpt/context/context-cleanup.phpt
+++ b/otel/tests/phpt/context/context-cleanup.phpt
@@ -28,13 +28,13 @@ var_dump("scope detached");
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::request: event src/request.rs:%d message=RINIT::not auto-creating root span...
 string(16) "activate context"
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Storing context instance 1 (ref count after clone = 3)
-[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Storing context: 1
+[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Storing context: Some(1)
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Attaching context instance 1
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Getting context instance 1
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Cloned context instance 1 (ref count after clone = 4)
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Before attach: context instance 1 has ref count = 5
 string(17) "unsetting context"
-[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Context::__destruct for context_id = 1
+[%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::context: event src/context/context.rs:%d message=Context::__destruct for context_id = Some(1)
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Maybe remove context for instance 1
 [%s] [DEBUG] [pid=%d] [ThreadId(%d)] otel::context::storage: event src/context/storage.rs:%d message=Cannot remove context instance 1 (ref count = 2, still in use)
 string(15) "detaching scope"


### PR DESCRIPTION
This pull request refactors context management in the OpenTelemetry PHP extension, shifting from using raw `u64` context IDs (with `0` as a special value) to using `Option<u64>` for more idiomatic and safer Rust code. This change affects context creation, attachment, detachment, and storage, leading to clearer handling of absent or invalid context IDs. Additionally, some cleanup and minor improvements were made to the codebase and build system.

### Context management refactor

* Refactored context ID handling throughout the codebase to use `Option<u64>` instead of `u64` with `0` as a sentinel value, improving safety and clarity in context operations (`store_context_instance`, `get_context_instance`, `maybe_remove_context_instance`, `attach_context`, `detach_context`, etc.) [[1]](diffhunk://#diff-067bafb5a7e19ba513e26300f85e1714ae3ba65b4e25d2648310135861ab39feL42-R72) [[2]](diffhunk://#diff-067bafb5a7e19ba513e26300f85e1714ae3ba65b4e25d2648310135861ab39feL80-L155) [[3]](diffhunk://#diff-962a6d6ad816897ec94753a390ab39d9baacf2292323b9813554ab61af1364e1L52-R55) [[4]](diffhunk://#diff-962a6d6ad816897ec94753a390ab39d9baacf2292323b9813554ab61af1364e1L108-R114) [[5]](diffhunk://#diff-962a6d6ad816897ec94753a390ab39d9baacf2292323b9813554ab61af1364e1R128-R134) [[6]](diffhunk://#diff-4b39fa218bbd81cc6760b60899206b483cf3dc77c5a4e546fe0a15d44f91012bL46-R64) [[7]](diffhunk://#diff-067bafb5a7e19ba513e26300f85e1714ae3ba65b4e25d2648310135861ab39feL194-R210) [[8]](diffhunk://#diff-1f16d7640bf2d0bfab15a57af7d81962a621d6f0796972b9e3779167bfc1bcdbL219-L225) [[9]](diffhunk://#diff-1f16d7640bf2d0bfab15a57af7d81962a621d6f0796972b9e3779167bfc1bcdbL244-R243) [[10]](diffhunk://#diff-1f16d7640bf2d0bfab15a57af7d81962a621d6f0796972b9e3779167bfc1bcdbL273-R272) [[11]](diffhunk://#diff-de2eb05bd0b83a3cdb7077a3e73ab2b1dc91d1fb1067c8deaa11693fc9a15387L59-R60) [[12]](diffhunk://#diff-de2eb05bd0b83a3cdb7077a3e73ab2b1dc91d1fb1067c8deaa11693fc9a15387L72-R93).
* Added helper function `get_instance_id` to extract a valid context ID from a PHP object, replacing manual property access and conversion logic [[1]](diffhunk://#diff-962a6d6ad816897ec94753a390ab39d9baacf2292323b9813554ab61af1364e1R128-R134) [[2]](diffhunk://#diff-4b39fa218bbd81cc6760b60899206b483cf3dc77c5a4e546fe0a15d44f91012bL3-R6) [[3]](diffhunk://#diff-72c71a44961355d0fba12b2e61b3b0c76a4c40c8ad0a42fdee31c534081152c1L10-L12).

### Local root span management

* Updated local root span functions to use `Option<u64>` for context IDs, including storing, retrieving, and removing local root spans, ensuring correct cleanup and avoiding accidental removal of unrelated contexts [[1]](diffhunk://#diff-de2eb05bd0b83a3cdb7077a3e73ab2b1dc91d1fb1067c8deaa11693fc9a15387L59-R60) [[2]](diffhunk://#diff-de2eb05bd0b83a3cdb7077a3e73ab2b1dc91d1fb1067c8deaa11693fc9a15387L72-R93) [[3]](diffhunk://#diff-4b39fa218bbd81cc6760b60899206b483cf3dc77c5a4e546fe0a15d44f91012bL46-R64).

### Codebase cleanup

* Removed unused Tokio runtime initialization and related code, as it is no longer necessary for the current exporter protocol handling [[1]](diffhunk://#diff-284fca3723666f5224086f0d11681cf5de6e886abd4dc6f4b870cbd3024981eeL48) [[2]](diffhunk://#diff-284fca3723666f5224086f0d11681cf5de6e886abd4dc6f4b870cbd3024981eeL106-L110) [[3]](diffhunk://#diff-284fca3723666f5224086f0d11681cf5de6e886abd4dc6f4b870cbd3024981eeL195-R201) [[4]](diffhunk://#diff-284fca3723666f5224086f0d11681cf5de6e886abd4dc6f4b870cbd3024981eeL231-L242) [[5]](diffhunk://#diff-284fca3723666f5224086f0d11681cf5de6e886abd4dc6f4b870cbd3024981eeL256-L267).

### Build system improvements

* Updated the `Makefile` to clean and update dependencies for the new `psr18` test suite, ensuring consistent test environments.

### Minor improvements

* Improved debug logging for context operations to use `{:?}` formatting and more descriptive messages, aiding in troubleshooting and development [[1]](diffhunk://#diff-962a6d6ad816897ec94753a390ab39d9baacf2292323b9813554ab61af1364e1L52-R55) [[2]](diffhunk://#diff-962a6d6ad816897ec94753a390ab39d9baacf2292323b9813554ab61af1364e1L108-R114) [[3]](diffhunk://#diff-067bafb5a7e19ba513e26300f85e1714ae3ba65b4e25d2648310135861ab39feL42-R72).

These changes collectively make context management safer and more idiomatic, reduce potential bugs, and improve maintainability of the codebase.