### PR TITLE
adding dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/otel/Makefile
+++ b/otel/Makefile
@@ -15,7 +15,6 @@ build-test:
 	cargo build --features test
 	cp target/debug/libotel.so modules/otel.so
 re: build-test
-	phpize
 	php -d extension=target/debug/libotel.so --re otel
 check:
 	cargo check
@@ -38,10 +37,10 @@ update:
 	@echo "✅ Composer dependencies updated"
 clean-build-test: clean test-all
 test: build-test
-	@echo "Running all tests..."
+	@echo "Running functional tests..."
 	php run-tests.php -q --show-diff tests/phpt/
 test-all: build-test
-	@echo "Running functional tests..."
+	@echo "Running all tests..."
 	php run-tests.php -q tests/
 test-export: build-test
 	@echo "Running live export tests..."

--- a/otel/src/context/context.rs
+++ b/otel/src/context/context.rs
@@ -51,9 +51,7 @@ pub fn build_context_class(
         .add_method("__destruct", Visibility::Public, |this, _| {
             let context_id = get_instance_id(this);
             debug!("Context::__destruct for context_id = {:?}", context_id);
-            if context_id.is_some() {
-                storage::maybe_remove_context_instance(context_id);
-            }
+            storage::maybe_remove_context_instance(context_id);
             Ok::<_, Infallible>(())
         });
 


### PR DESCRIPTION
This pull request introduces configuration for automated dependency updates, refines test output messaging, and simplifies resource cleanup in the context module. The most important changes are grouped below:

**Automation and Dependency Management**

* Added a `.github/dependabot.yml` configuration file to enable weekly automated updates for Rust dependencies using Cargo.

**Testing Workflow Improvements**

* Updated messaging in the `otel/Makefile` to clarify when functional tests versus all tests are being run, improving the clarity of test output.
* Simplified the `build-test` target in `otel/Makefile` by removing the unnecessary `phpize` step, streamlining the build and test process.

**Codebase Simplification**

* In `otel/src/context/context.rs`, removed a redundant conditional in the `Context::__destruct` method to always attempt context cleanup, simplifying resource management logic.