### PR TITLE
use slices instead of strings for get_targets

### DIFF
--- a/otel/src/auto/plugin.rs
+++ b/otel/src/auto/plugin.rs
@@ -14,7 +14,7 @@ pub trait Plugin: Send + Sync {
 
 pub trait Handler: Send + Sync {
     /// Should the function in execute data be observed by this plugin?
-    fn get_targets(&self) -> Vec<(Option<String>, String)>;
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ];
     fn get_callbacks(&self) -> HandlerCallbacks;
 }
 

--- a/otel/src/auto/plugins/laminas.rs
+++ b/otel/src/auto/plugins/laminas.rs
@@ -95,10 +95,11 @@ impl Plugin for LaminasPlugin {
 pub struct LaminasApplicationRunHandler;
 
 impl Handler for LaminasApplicationRunHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some(r"Laminas\Mvc\Application".to_string()), "run".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Laminas\\Mvc\\Application"), "run"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -138,10 +139,11 @@ impl LaminasApplicationRunHandler {
 pub struct LaminasCompleteRequestHandler;
 
 impl Handler for LaminasCompleteRequestHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some(r"Laminas\Mvc\Application".to_string()), "completeRequest".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Laminas\\Mvc\\Application"), "completeRequest"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -198,10 +200,11 @@ impl LaminasCompleteRequestHandler {
 pub struct LaminasRouteHandler;
 
 impl Handler for LaminasRouteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some(r"Laminas\Mvc\MvcEvent".to_string()), "setRouteMatch".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Laminas\\Mvc\\MvcEvent"), "setRouteMatch"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -262,10 +265,11 @@ impl LaminasRouteHandler {
 pub struct LaminasDbConnectHandler;
 
 impl Handler for LaminasDbConnectHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some(r"Laminas\Db\Adapter\Driver\AbstractConnection".to_string()), "connect".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Laminas\\Db\\Adapter\\Driver\\AbstractConnection"), "connect"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -338,10 +342,11 @@ impl LaminasDbConnectHandler {
 pub struct LaminasStatementPrepareHandler;
 
 impl Handler for LaminasStatementPrepareHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some(r"Laminas\Db\Adapter\Driver\StatementInterface".to_string()), "prepare".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Laminas\\Db\\Adapter\\Driver\\StatementInterface"), "prepare"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -452,10 +457,11 @@ impl LaminasStatementPrepareHandler {
 pub struct LaminasStatementExecuteHandler;
 
 impl Handler for LaminasStatementExecuteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some(r"Laminas\Db\Adapter\Driver\StatementInterface".to_string()), "execute".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Laminas\\Db\\Adapter\\Driver\\StatementInterface"), "execute"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -512,10 +518,11 @@ impl LaminasStatementExecuteHandler {
 pub struct LaminasConnectionExecuteHandler;
 
 impl Handler for LaminasConnectionExecuteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some(r"Laminas\Db\Adapter\Driver\ConnectionInterface".to_string()), "execute".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Laminas\\Db\\Adapter\\Driver\\ConnectionInterface"), "execute"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {

--- a/otel/src/auto/plugins/psr18.rs
+++ b/otel/src/auto/plugins/psr18.rs
@@ -55,10 +55,11 @@ impl Plugin for Psr18Plugin {
 pub struct Psr18SendRequestHandler;
 
 impl Handler for Psr18SendRequestHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some(r"Psr\Http\Client\ClientInterface".to_string()), "sendRequest".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Psr\Http\Client\ClientInterface"), "sendRequest"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {

--- a/otel/src/auto/plugins/test.rs
+++ b/otel/src/auto/plugins/test.rs
@@ -54,14 +54,15 @@ impl Plugin for TestPlugin {
 pub struct DemoHandler;
 
 impl Handler for DemoHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some("DemoClass".to_string()), "test".to_string()),
-            (Some("DemoClass".to_string()), "inner".to_string()),
-            (None, "phpversion".to_string()),
-            (Some("IDemo".to_string()), "foo".to_string()),
-            (Some("IDemo".to_string()), "bar".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 5] = [
+            (Some("DemoClass"), "test"),
+            (Some("DemoClass"), "inner"),
+            (None, "phpversion"),
+            (Some("IDemo"), "foo"),
+            (Some("IDemo"), "bar"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -101,10 +102,11 @@ impl DemoHandler {
 pub struct DemoFunctionHandler;
 
 impl Handler for DemoFunctionHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (None, "demoFunction".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (None, "demoFunction"),
+        ];
+        &TARGETS
     }
 
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -153,11 +155,12 @@ impl DemoFunctionHandler {
 
 pub struct TestClassHandler;
 impl Handler for TestClassHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some(r"OpenTelemetry\Test\ITestClass".to_string()), "getString".to_string()),
-            (Some(r"OpenTelemetry\Test\ITestClass".to_string()), "throwException".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 2] = [
+            (Some(r"OpenTelemetry\Test\ITestClass"), "getString"),
+            (Some(r"OpenTelemetry\Test\ITestClass"), "throwException"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {

--- a/otel/src/auto/plugins/zf1.rs
+++ b/otel/src/auto/plugins/zf1.rs
@@ -91,10 +91,11 @@ impl Plugin for Zf1Plugin {
 pub struct Zf1RouteHandler;
 
 impl Handler for Zf1RouteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some("Zend_Controller_Router_Interface".to_string()), "route".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Zend_Controller_Router_Interface"), "route"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -179,10 +180,11 @@ impl Zf1RouteHandler {
 
 pub struct Zf1SendResponseHandler;
 impl Handler for Zf1SendResponseHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some("Zend_Controller_Response_Abstract".to_string()), "sendResponse".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Zend_Controller_Response_Abstract"), "sendResponse"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -248,10 +250,11 @@ impl Zf1SendResponseHandler {
 pub struct Zf1AdapterConnectHandler;
 
 impl Handler for Zf1AdapterConnectHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some("Zend_Db_Adapter_Abstract".to_string()), "_connect".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Zend_Db_Adapter_Abstract"), "_connect"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -332,10 +335,11 @@ impl Zf1AdapterConnectHandler {
 pub struct Zf1AdapterPrepareHandler;
 
 impl Handler for Zf1AdapterPrepareHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some("Zend_Db_Adapter_Abstract".to_string()), "prepare".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Zend_Db_Adapter_Abstract"), "prepare"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {
@@ -431,10 +435,11 @@ impl Zf1AdapterPrepareHandler {
 pub struct Zf1StatementExecuteHandler;
 
 impl Handler for Zf1StatementExecuteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
-        vec![
-            (Some("Zend_Db_Statement_Interface".to_string()), "execute".to_string()),
-        ]
+    fn get_targets(&self) -> &[ (Option<&'static str>, &'static str) ] {
+        static TARGETS: [(Option<&'static str>, &'static str); 1] = [
+            (Some(r"Zend_Db_Statement_Interface"), "execute"),
+        ];
+        &TARGETS
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
         HandlerCallbacks {


### PR DESCRIPTION
This pull request refactors the way handler targets are defined and used throughout the OpenTelemetry auto-instrumentation plugins. The main change is moving from dynamically allocated `Vec<(Option<String>, String)>` to static slices with `&'static str`, improving performance and reducing memory allocations. This update affects the core trait definition, plugin manager logic, and all plugin handler implementations.

### Core API and Type Refactoring

* Updated the `Handler` trait's `get_targets` method to return a static slice of `(Option<&'static str>, &'static str)` instead of a dynamically allocated `Vec<(Option<String>, String)>`, enabling more efficient and static target definitions.

### Plugin Manager Logic

* Refactored the `should_trace` function in `plugin_manager.rs` to use the new static slice type and avoid unnecessary string allocations/conversions, streamlining the matching logic for observed function/method names. [[1]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L121-R121) [[2]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L130-L145) [[3]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L155-R152)

### Laminas Plugin Handlers

* All Laminas plugin handler implementations now define their targets as static arrays with `&'static str`, returning references to these arrays rather than allocating new vectors. This change applies to handlers for application run, complete request, route, DB connect, statement prepare, statement execute, and connection execute. [[1]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL98-R102) [[2]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL141-R146) [[3]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL201-R207) [[4]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL265-R272) [[5]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL341-R349) [[6]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL455-R464) [[7]](diffhunk://#diff-7072c987ee5eee7981bd3acf3a63fc6397b8928294ef25c27a41a4e3db390d7fL515-R525)

### PSR-18 Plugin Handlers

* The PSR-18 plugin handler now uses the static slice approach for its target definition, improving consistency and efficiency.

### Test and ZF1 Plugin Handlers

* All test and ZF1 plugin handlers have been updated to use static arrays for their targets, removing dynamic allocation and string conversion. This includes handlers for demo, demo function, test class, ZF1 route, send response, adapter connect, adapter prepare, and statement execute. [[1]](diffhunk://#diff-79f640991c11f5eb66f95f9c20e672c5901e88d588311c982a36a97fee5c8cdcL57-R65) [[2]](diffhunk://#diff-79f640991c11f5eb66f95f9c20e672c5901e88d588311c982a36a97fee5c8cdcL104-R109) [[3]](diffhunk://#diff-79f640991c11f5eb66f95f9c20e672c5901e88d588311c982a36a97fee5c8cdcL156-R163) [[4]](diffhunk://#diff-84e8a5799aa85d4d68929b67c85c63c360bd9b97d20f3dcced68670ba3510eadL94-R98) [[5]](diffhunk://#diff-84e8a5799aa85d4d68929b67c85c63c360bd9b97d20f3dcced68670ba3510eadL182-R187) [[6]](diffhunk://#diff-84e8a5799aa85d4d68929b67c85c63c360bd9b97d20f3dcced68670ba3510eadL251-R257) [[7]](diffhunk://#diff-84e8a5799aa85d4d68929b67c85c63c360bd9b97d20f3dcced68670ba3510eadL335-R342) [[8]](diffhunk://#diff-84e8a5799aa85d4d68929b67c85c63c360bd9b97d20f3dcced68670ba3510eadL434-R442)