### PR TITLE
Optimize observers

### DIFF
--- a/otel/src/auto/execute.rs
+++ b/otel/src/auto/execute.rs
@@ -6,6 +6,7 @@ use phper::{
 use crate::{
     auto::{
         execute_data::{
+            get_fqn,
             get_global_exception,
             get_function_and_class_name,
         },
@@ -64,15 +65,15 @@ where
         }
     };
 
-    let key = match get_function_and_class_name(exec_data) {
-        Ok((Some(func), Some(cls))) => format!("{}::{}", cls, func),
-        Ok((Some(func), None)) => func,
-        _ => {
+    let key = match get_fqn(exec_data) {
+        Some(fqn) => fqn,
+        None => {
             upstream(Some(exec_data), return_value);
             return;
         },
     };
 
+    // Check if we've already decided to observe this function or not
     if let Some(observed) = OBSERVER_MAP.with(|map| map.borrow_mut().get(&key).copied()) {
         if !observed {
             upstream(Some(exec_data), return_value);

--- a/otel/src/auto/execute.rs
+++ b/otel/src/auto/execute.rs
@@ -8,7 +8,6 @@ use crate::{
         execute_data::{
             get_fqn,
             get_global_exception,
-            get_function_and_class_name,
         },
         plugin_manager::{
             get_global as get_plugin_manager,

--- a/otel/src/auto/execute_data.rs
+++ b/otel/src/auto/execute_data.rs
@@ -59,13 +59,13 @@ pub fn get_function_and_class_name(
     Ok((function_name, class_name))
 }
 
-pub fn get_fqn(execute_data: &ExecuteData) -> String {
+pub fn get_fqn(execute_data: &ExecuteData) -> Option<String> {
     let (function_name, class_name) = get_function_and_class_name(execute_data).unwrap_or((None, None));
 
     match (class_name, function_name) {
-        (Some(cls), Some(func)) => format!("{}::{}", cls, func),
-        (None, Some(func)) => func,
-        _ => "<unknown>".to_string(),
+        (Some(cls), Some(func)) => Some(format!("{}::{}", cls, func)),
+        (None, Some(func)) => Some(func),
+        _ => None,
     }
 }
 
@@ -115,7 +115,7 @@ pub fn get_global_exception() -> Option<&'static mut ZObj> {
 
 // Default auto-instrumentation attributes from ExecuteData
 pub fn get_default_attributes(execute_data: &ExecuteData) -> Vec<KeyValue> {
-    let mut attributes = vec![KeyValue::new("code.function.name".to_string(), get_fqn(execute_data))];
+    let mut attributes = vec![KeyValue::new("code.function.name".to_string(), get_fqn(execute_data).unwrap())];
     unsafe {
         if let Some((file, line)) = get_file_and_line(execute_data) {
             attributes.push(KeyValue::new("code.file.path".to_string(), file));

--- a/otel/src/auto/observer.rs
+++ b/otel/src/auto/observer.rs
@@ -22,10 +22,10 @@ use crate::{
 };
 use std::{
     collections::HashMap,
-    sync::{OnceLock, RwLock},
+    sync::{Arc, OnceLock, RwLock},
 };
 
-static FUNCTION_OBSERVERS: OnceLock<RwLock<HashMap<String, FunctionObserver>>> = OnceLock::new();
+static FUNCTION_OBSERVERS: OnceLock<RwLock<HashMap<String, Arc<FunctionObserver>>>> = OnceLock::new();
 
 pub fn init() {
     tracing::debug!("Observer::init");

--- a/otel/src/auto/plugins/test.rs
+++ b/otel/src/auto/plugins/test.rs
@@ -79,7 +79,7 @@ impl DemoHandler {
     unsafe extern "C" fn pre_callback(exec_data: *mut ExecuteData) {
         let tracer = tracer_provider::get_tracer_provider().tracer("php.otel.auto.test");
         let exec_data_ref = unsafe { &*exec_data };
-        let span_name = get_fqn(exec_data_ref);
+        let span_name = get_fqn(exec_data_ref).unwrap();
 
         utils::start_and_activate_span(tracer, &span_name, vec![], exec_data, opentelemetry::trace::SpanKind::Internal);
     }


### PR DESCRIPTION
This pull request refactors the function observer mechanism in the auto-instrumentation code, focusing on improving performance and reliability by introducing caching and simplifying function identification. The changes remove unnecessary state tracking, streamline function name handling, and ensure observers are efficiently reused. Additionally, the observer cache is now managed using `Arc` for thread safety and better resource management.

**Function Observer Caching and Management**
* Introduced a thread-safe cache for function observers using `Arc` and `RwLock`, improving performance by avoiding redundant observer construction (`otel/src/auto/plugin_manager.rs`, `otel/src/auto/observer.rs`). [[1]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L16-R31) [[2]](diffhunk://#diff-c2625c60cd7d339eeaba36a845902c2bfcaca82a1bedc27544d0490368fb2c27L25-R28) [[3]](diffhunk://#diff-c2625c60cd7d339eeaba36a845902c2bfcaca82a1bedc27544d0490368fb2c27L42-R52) [[4]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543R48) [[5]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L78-L92) [[6]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L103-R121)
* Updated the observer initialization and retrieval logic to use this cache, ensuring observers are reused across function calls (`otel/src/auto/plugin_manager.rs`). [[1]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L78-L92) [[2]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L103-R121)

**Function Name Handling and Identification**
* Refactored `get_fqn` to return an `Option<String>` instead of a default string, allowing more robust handling of unknown or invalid function names (`otel/src/auto/execute_data.rs`).
* Updated all usages of `get_fqn` to handle the new return type, using `.unwrap()` where a valid function name is required (`otel/src/auto/observer.rs`, `otel/src/auto/plugins/test.rs`, `otel/src/auto/execute_data.rs`). [[1]](diffhunk://#diff-c2625c60cd7d339eeaba36a845902c2bfcaca82a1bedc27544d0490368fb2c27L71-R73) [[2]](diffhunk://#diff-c2625c60cd7d339eeaba36a845902c2bfcaca82a1bedc27544d0490368fb2c27L89-R91) [[3]](diffhunk://#diff-79f640991c11f5eb66f95f9c20e672c5901e88d588311c982a36a97fee5c8cdcL82-R82) [[4]](diffhunk://#diff-60bd3c6a28b0289099121f7856aae931c6d3ffb542cc4c44696cdbc7a9db7a4aL118-R118)

**Removal of Unnecessary State and Simplification**
* Removed the `OBSERVER_MAP` and related logic that tracked observed functions, simplifying execution flow and reducing memory footprint (`otel/src/auto/execute.rs`). [[1]](diffhunk://#diff-c11ae1a792baab3b4f5f4cd50989de66c0e171cba946541325aa304d4804bc66L19-L26) [[2]](diffhunk://#diff-c11ae1a792baab3b4f5f4cd50989de66c0e171cba946541325aa304d4804bc66L67-L90)
* Simplified the observer hook signatures and removed passing of function/class names where no longer needed (`otel/src/auto/execute.rs`). [[1]](diffhunk://#diff-c11ae1a792baab3b4f5f4cd50989de66c0e171cba946541325aa304d4804bc66L57-R51) [[2]](diffhunk://#diff-c11ae1a792baab3b4f5f4cd50989de66c0e171cba946541325aa304d4804bc66L110-R85) [[3]](diffhunk://#diff-c11ae1a792baab3b4f5f4cd50989de66c0e171cba946541325aa304d4804bc66L120-R95) [[4]](diffhunk://#diff-c11ae1a792baab3b4f5f4cd50989de66c0e171cba946541325aa304d4804bc66L148-R123)

**Improved Target Matching Logic**
* Refactored the target matching logic in `should_trace` for greater clarity and reliability, especially in handling class/method pairs and interfaces (`otel/src/auto/plugin_manager.rs`). [[1]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L122-R160) [[2]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L155-L162)

**Minor Dependency and Import Updates**
* Updated imports and removed unused dependencies to reflect the new observer and cache logic (`otel/src/auto/execute.rs`, `otel/src/auto/plugin_manager.rs`). [[1]](diffhunk://#diff-c11ae1a792baab3b4f5f4cd50989de66c0e171cba946541325aa304d4804bc66L10) [[2]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L16-R31)

Let me know if you’d like a deeper walkthrough of any of these areas!