### PR TITLE
String to slice

### DIFF
--- a/otel/src/auto/plugin.rs
+++ b/otel/src/auto/plugin.rs
@@ -22,7 +22,7 @@ pub trait Plugin: Send + Sync {
 
 pub trait Handler: Send + Sync {
     /// Should the function in execute data be observed by this plugin?
-    fn get_targets(&self) -> Vec<(Option<String>, String)>;
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)>;
     fn get_callbacks(&self) -> HandlerCallbacks;
 }
 

--- a/otel/src/auto/plugin/laminas.rs
+++ b/otel/src/auto/plugin/laminas.rs
@@ -97,9 +97,9 @@ impl Plugin for LaminasPlugin {
 pub struct LaminasApplicationRunHandler;
 
 impl Handler for LaminasApplicationRunHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some(r"Laminas\Mvc\Application".to_string()), "run".to_string()),
+            (Some(r"Laminas\Mvc\Application"), "run"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -140,9 +140,9 @@ impl LaminasApplicationRunHandler {
 pub struct LaminasCompleteRequestHandler;
 
 impl Handler for LaminasCompleteRequestHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some(r"Laminas\Mvc\Application".to_string()), "completeRequest".to_string()),
+            (Some(r"Laminas\Mvc\Application"), "completeRequest"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -200,9 +200,9 @@ impl LaminasCompleteRequestHandler {
 pub struct LaminasRouteHandler;
 
 impl Handler for LaminasRouteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some(r"Laminas\Mvc\MvcEvent".to_string()), "setRouteMatch".to_string()),
+            (Some(r"Laminas\Mvc\MvcEvent"), "setRouteMatch"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -264,9 +264,9 @@ impl LaminasRouteHandler {
 pub struct LaminasDbConnectHandler;
 
 impl Handler for LaminasDbConnectHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some(r"Laminas\Db\Adapter\Driver\AbstractConnection".to_string()), "connect".to_string()),
+            (Some(r"Laminas\Db\Adapter\Driver\AbstractConnection"), "connect"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -340,9 +340,9 @@ impl LaminasDbConnectHandler {
 pub struct LaminasStatementPrepareHandler;
 
 impl Handler for LaminasStatementPrepareHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some(r"Laminas\Db\Adapter\Driver\StatementInterface".to_string()), "prepare".to_string()),
+            (Some(r"Laminas\Db\Adapter\Driver\StatementInterface"), "prepare"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -454,9 +454,9 @@ impl LaminasStatementPrepareHandler {
 pub struct LaminasStatementExecuteHandler;
 
 impl Handler for LaminasStatementExecuteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some(r"Laminas\Db\Adapter\Driver\StatementInterface".to_string()), "execute".to_string()),
+            (Some(r"Laminas\Db\Adapter\Driver\StatementInterface"), "execute"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -513,9 +513,9 @@ impl LaminasStatementExecuteHandler {
 pub struct LaminasConnectionExecuteHandler;
 
 impl Handler for LaminasConnectionExecuteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some(r"Laminas\Db\Adapter\Driver\ConnectionInterface".to_string()), "execute".to_string()),
+            (Some(r"Laminas\Db\Adapter\Driver\ConnectionInterface"), "execute"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {

--- a/otel/src/auto/plugin/psr18.rs
+++ b/otel/src/auto/plugin/psr18.rs
@@ -55,9 +55,9 @@ impl Plugin for Psr18Plugin {
 pub struct Psr18SendRequestHandler;
 
 impl Handler for Psr18SendRequestHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some(r"Psr\Http\Client\ClientInterface".to_string()), "sendRequest".to_string()),
+            (Some(r"Psr\Http\Client\ClientInterface"), "sendRequest"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {

--- a/otel/src/auto/plugin/test.rs
+++ b/otel/src/auto/plugin/test.rs
@@ -55,13 +55,13 @@ impl Plugin for TestPlugin {
 pub struct DemoHandler;
 
 impl Handler for DemoHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some("DemoClass".to_string()), "test".to_string()),
-            (Some("DemoClass".to_string()), "inner".to_string()),
-            (None, "phpversion".to_string()),
-            (Some("IDemo".to_string()), "foo".to_string()),
-            (Some("IDemo".to_string()), "bar".to_string()),
+            (Some("DemoClass"), "test"),
+            (Some("DemoClass"), "inner"),
+            (None, "phpversion"),
+            (Some("IDemo"), "foo"),
+            (Some("IDemo"), "bar"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -97,9 +97,9 @@ impl DemoHandler {
 pub struct DemoHelloHandler;
 
 impl Handler for DemoHelloHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some("DemoClass".to_string()), "hello".to_string()),
+            (Some("DemoClass"), "hello"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -131,9 +131,9 @@ impl DemoHelloHandler {
 pub struct DemoFunctionHandler;
 
 impl Handler for DemoFunctionHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (None, "demoFunction".to_string()),
+            (None, "demoFunction"),
         ]
     }
 
@@ -178,10 +178,10 @@ impl DemoFunctionHandler {
 
 pub struct TestClassHandler;
 impl Handler for TestClassHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some(r"OpenTelemetry\Test\ITestClass".to_string()), "getString".to_string()),
-            (Some(r"OpenTelemetry\Test\ITestClass".to_string()), "throwException".to_string()),
+            (Some(r"OpenTelemetry\Test\ITestClass"), "getString"),
+            (Some(r"OpenTelemetry\Test\ITestClass"), "throwException"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {

--- a/otel/src/auto/plugin/zf1.rs
+++ b/otel/src/auto/plugin/zf1.rs
@@ -93,9 +93,9 @@ impl Plugin for Zf1Plugin {
 pub struct Zf1RouteHandler;
 
 impl Handler for Zf1RouteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some("Zend_Controller_Router_Interface".to_string()), "route".to_string()),
+            (Some("Zend_Controller_Router_Interface"), "route"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -182,9 +182,9 @@ impl Zf1RouteHandler {
 
 pub struct Zf1SendResponseHandler;
 impl Handler for Zf1SendResponseHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some("Zend_Controller_Response_Abstract".to_string()), "sendResponse".to_string()),
+            (Some("Zend_Controller_Response_Abstract"), "sendResponse"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -251,9 +251,9 @@ impl Zf1SendResponseHandler {
 pub struct Zf1AdapterConnectHandler;
 
 impl Handler for Zf1AdapterConnectHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some("Zend_Db_Adapter_Abstract".to_string()), "_connect".to_string()),
+            (Some("Zend_Db_Adapter_Abstract"), "_connect"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -337,9 +337,9 @@ impl Zf1AdapterConnectHandler {
 pub struct Zf1AdapterPrepareHandler;
 
 impl Handler for Zf1AdapterPrepareHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some("Zend_Db_Adapter_Abstract".to_string()), "prepare".to_string()),
+            (Some("Zend_Db_Adapter_Abstract"), "prepare"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {
@@ -436,9 +436,9 @@ impl Zf1AdapterPrepareHandler {
 pub struct Zf1StatementExecuteHandler;
 
 impl Handler for Zf1StatementExecuteHandler {
-    fn get_targets(&self) -> Vec<(Option<String>, String)> {
+    fn get_targets(&self) -> Vec<(Option<&'static str>, &'static str)> {
         vec![
-            (Some("Zend_Db_Statement_Interface".to_string()), "execute".to_string()),
+            (Some("Zend_Db_Statement_Interface"), "execute"),
         ]
     }
     fn get_callbacks(&self) -> HandlerCallbacks {

--- a/otel/src/util.rs
+++ b/otel/src/util.rs
@@ -15,7 +15,9 @@ use std::ffi::CStr;
 pub fn zval_to_key_value(key: &str, value: &ZVal) -> Option<KeyValue> {
     let type_info = value.get_type_info();
     if type_info.is_string() {
-        return value.as_z_str().and_then(|z| z.to_str().ok()).map(|s| KeyValue::new(key.to_string(), s.to_string()));
+        return value.as_z_str()
+            .and_then(|z| z.to_str().ok())
+            .map(|s| KeyValue::new(key.to_string(), s.to_string()));
     }
     if type_info.is_long() {
         return value.as_long().map(|v| KeyValue::new(key.to_string(), v));
@@ -41,8 +43,8 @@ pub fn zval_arr_to_key_value_vec(arr: ZArray) -> Vec<KeyValue> {
         match key {
             IterKey::Index(_) => {}, // Skip integer keys
             IterKey::ZStr(zstr) => {
-                if let Some(key_str) = zstr.to_str().ok().map(|s| s.to_string()) {
-                    if let Some(kv) = zval_to_key_value(&key_str, value) {
+                if let Some(key_str) = zstr.to_str().ok() {
+                    if let Some(kv) = zval_to_key_value(key_str, value) {
                         result.push(kv);
                     }
                 }


### PR DESCRIPTION
This pull request refactors the handler target definitions across several plugins in the `otel/src/auto/plugin` directory to use static string references instead of owned `String` types. This change improves performance and memory usage by avoiding unnecessary allocations, and ensures consistency in how class and method names are represented throughout the codebase. Additionally, related logic in the plugin manager and test utilities has been updated to support these changes.

### Type consistency and performance improvements

* Changed the target tuple in the `Handler` trait and all handler implementations from `(Option<String>, String)` to `(Option<&'static str>, &'static str)`, reducing allocations and enabling more efficient comparisons. (`otel/src/auto/plugin.rs`, `otel/src/auto/plugin/laminas.rs`, `otel/src/auto/plugin/psr18.rs`, `otel/src/auto/plugin/test.rs`, `otel/src/auto/plugin/zf1.rs`) [[1]](diffhunk://#diff-f316d14e7ae5054a3f3972dfa1bcd73682d29f950461cfb0c0e19bde478704caL25-R25) [[2]](diffhunk://#diff-9165cfd1e49d33d1138f18888928d5c8e27c3178cc34f8b551e7927e0e792777L100-R102) [[3]](diffhunk://#diff-9165cfd1e49d33d1138f18888928d5c8e27c3178cc34f8b551e7927e0e792777L143-R145) [[4]](diffhunk://#diff-9165cfd1e49d33d1138f18888928d5c8e27c3178cc34f8b551e7927e0e792777L203-R205) [[5]](diffhunk://#diff-9165cfd1e49d33d1138f18888928d5c8e27c3178cc34f8b551e7927e0e792777L267-R269) [[6]](diffhunk://#diff-9165cfd1e49d33d1138f18888928d5c8e27c3178cc34f8b551e7927e0e792777L343-R345) [[7]](diffhunk://#diff-9165cfd1e49d33d1138f18888928d5c8e27c3178cc34f8b551e7927e0e792777L457-R459) [[8]](diffhunk://#diff-9165cfd1e49d33d1138f18888928d5c8e27c3178cc34f8b551e7927e0e792777L516-R518) [[9]](diffhunk://#diff-110ae844987a2ae0e90887d2a82dc818c7373ce89cc1b2d315c1e55a7e4c4e87L58-R60) [[10]](diffhunk://#diff-4f11b6a25c5ffb0ef7e459353acd87614cdf685ef0ddf0a72166766b0bced210L58-R64) [[11]](diffhunk://#diff-4f11b6a25c5ffb0ef7e459353acd87614cdf685ef0ddf0a72166766b0bced210L100-R102) [[12]](diffhunk://#diff-4f11b6a25c5ffb0ef7e459353acd87614cdf685ef0ddf0a72166766b0bced210L134-R136) [[13]](diffhunk://#diff-4f11b6a25c5ffb0ef7e459353acd87614cdf685ef0ddf0a72166766b0bced210L181-R184) [[14]](diffhunk://#diff-3ee087e57986296a98179ab29a07e3984db102499d931339dede20ff667a137aL96-R98) [[15]](diffhunk://#diff-3ee087e57986296a98179ab29a07e3984db102499d931339dede20ff667a137aL185-R187) [[16]](diffhunk://#diff-3ee087e57986296a98179ab29a07e3984db102499d931339dede20ff667a137aL254-R256) [[17]](diffhunk://#diff-3ee087e57986296a98179ab29a07e3984db102499d931339dede20ff667a137aL340-R342) [[18]](diffhunk://#diff-3ee087e57986296a98179ab29a07e3984db102499d931339dede20ff667a137aL439-R441)

### Plugin manager logic updates

* Updated the `should_trace` function in `otel/src/auto/plugin_manager.rs` to work with static string references, including changes to tuple construction and comparison logic. [[1]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L139-R139) [[2]](diffhunk://#diff-edcaaddc9a212efc46f8dc824092cfee2d3f3c0da068d4094e2f6e2bc5f64543L151-R156)
* Modified interface matching logic to convert static string references to owned strings where necessary for class entry lookups.

### Utility improvements

* Simplified string conversion and key-value creation logic in `otel/src/util.rs` to avoid unnecessary allocations and improve clarity. [[1]](diffhunk://#diff-4e0e1b5341b319ee338473e8a816e8de9ad93a5dd08a995fca25103d3e827417L18-R20) [[2]](diffhunk://#diff-4e0e1b5341b319ee338473e8a816e8de9ad93a5dd08a995fca25103d3e827417L44-R47)