### PR TITLE
Jit server init

### DIFF
--- a/otel/src/request.rs
+++ b/otel/src/request.rs
@@ -375,11 +375,12 @@ fn shutdown() {
     storage::clear_context_storage();
 }
 
-/// Ensure $_SERVER is initialized
+/// Ensure $_SERVER is initialized, which may not be true if auto_globals_jit is enabled.
 fn jit_initialization() {
     unsafe {
         let jit_initialization: u8 = pg!(auto_globals_jit).into();
         if jit_initialization != 0 {
+            tracing::debug!("JIT auto_globals_jit enabled, initializing $_SERVER");
             let mut server = "_SERVER".to_string();
             sys::zend_is_auto_global_str(server.as_mut_ptr().cast(), server.len());
         }

--- a/otel/src/request.rs
+++ b/otel/src/request.rs
@@ -2,6 +2,7 @@ use anyhow::Context as _;
 use phper::{
     eg,
     ini::ini_get,
+    pg,
     sg,
     sys,
     arrays::{IterKey, ZArr},
@@ -49,6 +50,7 @@ pub fn on_request_init() {
     if module::is_disabled() {
         return;
     }
+    jit_initialization();
     logging::init_once();
     tracing::debug!("OpenTelemetry::RINIT");
     init_environment();
@@ -373,13 +375,21 @@ fn shutdown() {
     storage::clear_context_storage();
 }
 
+/// Ensure $_SERVER is initialized
+fn jit_initialization() {
+    unsafe {
+        let jit_initialization: u8 = pg!(auto_globals_jit).into();
+        if jit_initialization != 0 {
+            let mut server = "_SERVER".to_string();
+            sys::zend_is_auto_global_str(server.as_mut_ptr().cast(), server.len());
+        }
+    }
+}
+
 // @see https://github.com/apache/skywalking-php/blob/v0.8.0/src/request.rs#L152
 #[allow(static_mut_refs)]
 fn get_request_server<'a>() -> anyhow::Result<&'a ZArr> {
     unsafe {
-        // Ensure $_SERVER is initialized
-        let mut server = "_SERVER".to_string();
-        sys::zend_is_auto_global_str(server.as_mut_ptr().cast(), server.len());
         let symbol_table = ZArr::from_mut_ptr(&mut eg!(symbol_table));
         let carrier = symbol_table
             .get("_SERVER")

--- a/otel/tests/http/http-fatal.phpt
+++ b/otel/tests/http/http-fatal.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test HTTP span with 500 error response
+Test HTTP span with fatal error
 --EXTENSIONS--
 otel
 --FILE--

--- a/otel/tests/phpt/request/request_init_server_with_jit.phpt
+++ b/otel/tests/phpt/request/request_init_server_with_jit.phpt
@@ -1,0 +1,19 @@
+--TEST--
+RINIT initializes $_SERVER with JIT enabled
+--EXTENSIONS--
+otel
+--ENV--
+OTEL_TRACES_EXPORTER=memory
+OTEL_SPAN_PROCESSOR=simple
+--INI--
+otel.log.level="debug"
+otel.log.file="/dev/stdout"
+otel.cli.enabled=1
+auto_globals_jit=On
+--FILE--
+<?php
+?>
+--EXPECTF--
+%A
+%s message=JIT auto_globals_jit enabled, initializing $_SERVER
+%A


### PR DESCRIPTION
This pull request introduces an important fix to ensure proper initialization of the `$_SERVER` superglobal in PHP when `auto_globals_jit` is enabled. The main change is the addition of logic to explicitly initialize `$_SERVER` during request initialization, which addresses potential issues with uninitialized superglobals in certain PHP configurations. The changes also include updates to tests to verify this behavior.

**Initialization and Environment Handling**

* Added a new `jit_initialization()` function in `otel/src/request.rs` that checks if `auto_globals_jit` is enabled and, if so, explicitly initializes the `$_SERVER` superglobal using `zend_is_auto_global_str`. This prevents issues when `$_SERVER` is not automatically initialized.
* Called the new `jit_initialization()` function at the start of the request lifecycle in `on_request_init()` to ensure the superglobal is always available.
* Updated imports to include `pg` for accessing PHP global variables, supporting the new initialization logic.

**Testing**

* Added a new PHPT test `request_init_server_with_jit.phpt` to verify that `$_SERVER` is properly initialized when `auto_globals_jit` is enabled, and that the debug log message is emitted.
* Updated the test description in `http-fatal.phpt` to clarify that it tests HTTP spans with fatal errors.