### PR TITLE
Improve sql

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,20 +39,21 @@ jobs:
 
       - name: Install dependencies
         working-directory: otel
-        run: |
-          pushd . && cd tests/auto/zf1 && composer update && popd
+        run: (cd tests/auto/zf1 && composer update --no-dev)
 
       - name: Install dependencies (7.1+)
         working-directory: otel
         if: matrix.php-version != '7.0'
-        run: |
-          pushd . && cd tests/auto/laminas && composer update && popd
+        run: (cd tests/auto/laminas && composer update --no-dev)
 
       - name: Install dependencies (7.2+)
         working-directory: otel
         if: matrix.php-version != '7.0' && matrix.php-version != '7.1'
-        run: |
-          pushd . && cd tests/auto/psr18 && composer update && popd
+        run: (cd tests/auto/psr18 && composer update --no-dev)
+
+      - name: Run cargo tests
+        working-directory: otel
+        run: cargo test --features test
 
       - name: Run tests
         working-directory: otel

--- a/otel/Makefile
+++ b/otel/Makefile
@@ -41,6 +41,7 @@ update:
 clean-build-test: clean test-all
 test: build-test
 	@echo "Running tests..."
+	cargo test
 	php run-tests.php -q tests/
 test-phpt: build-test
 	@echo "Running phpt tests..."

--- a/otel/src/auto/utils.rs
+++ b/otel/src/auto/utils.rs
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_select_distinct() {
-        let sql = "select count(distinct(first_name)) * FROM users";
+        let sql = "select count(distinct(first_name)) FROM users";
         assert_eq!(extract_span_name_from_sql(sql), Some("SELECT users".to_string()));
     }
 

--- a/otel/src/auto/utils.rs
+++ b/otel/src/auto/utils.rs
@@ -30,7 +30,7 @@ pub fn extract_span_name_from_sql(sql: &str) -> Option<String> {
         if let Some(after_from) = after_from {
             // If FROM is followed by a parenthesis, it's a subquery, not a table
             if after_from.starts_with('(') {
-                return None;
+                return Some("SELECT".to_string());
             }
             // Otherwise, match the table name
             let table_re = Regex::new(r#"^[`"a-zA-Z0-9_\.]+"#).unwrap();
@@ -146,8 +146,13 @@ mod tests {
     #[test]
     fn test_select_with_subquery_in_from() {
         let sql = "SELECT * FROM (SELECT * FROM users) AS sub";
-        // Should not match the subquery, but the outer FROM (which is a subquery, so None)
-        assert_eq!(extract_span_name_from_sql(sql), None);
+        assert_eq!(extract_span_name_from_sql(sql), Some("SELECT".to_string()));
+    }
+
+    #[test]
+    fn test_multiline_subquery() {
+        let sql = "SELECT *\n  FROM\n  (\n    SELECT * FROM users\n)";
+        assert_eq!(extract_span_name_from_sql(sql), Some("SELECT".to_string()));
     }
 
     #[test]

--- a/otel/src/auto/utils.rs
+++ b/otel/src/auto/utils.rs
@@ -20,28 +20,38 @@ use regex::Regex;
 
 pub fn extract_span_name_from_sql(sql: &str) -> Option<String> {
     let sql = sql.trim();
-    let select_re = Regex::new(r#"(?i)^\s*SELECT.*FROM\s+([`"a-zA-Z0-9_\.]+)"#).unwrap();
-    let insert_re = Regex::new(r#"(?i)^\s*INSERT\s+INTO\s+([`"a-zA-Z0-9_\.]+)"#).unwrap();
-    let update_re = Regex::new(r#"(?i)^\s*UPDATE\s+([`"a-zA-Z0-9_\.]+)"#).unwrap();
-    let delete_re = Regex::new(r#"(?i)^\s*DELETE\s+FROM\s+([`"a-zA-Z0-9_\.]+)"#).unwrap();
+    let select_re = Regex::new(r#"(?si)^\s*(SELECT)\b.*?\bFROM\b(.*)"#).unwrap();
+    let insert_re = Regex::new(r#"(?si)^\s*(INSERT)\s+INTO\s+([`"a-zA-Z0-9_\.]+)"#).unwrap();
+    let update_re = Regex::new(r#"(?si)^\s*(UPDATE)\s+([`"a-zA-Z0-9_\.]+)"#).unwrap();
+    let delete_re = Regex::new(r#"(?si)^\s*(DELETE)\s+FROM\s+([`"a-zA-Z0-9_\.]+)"#).unwrap();
 
     if let Some(caps) = select_re.captures(sql) {
-        let table = caps.get(1).map(|m| m.as_str().replace(['"', '`'], ""));
-        return table.map(|t| format!("SELECT {}", t));
+        let after_from = caps.get(2).map(|m| m.as_str().trim_start());
+        if let Some(after_from) = after_from {
+            // If FROM is followed by a parenthesis, it's a subquery, not a table
+            if after_from.starts_with('(') {
+                return None;
+            }
+            // Otherwise, match the table name
+            let table_re = Regex::new(r#"^[`"a-zA-Z0-9_\.]+"#).unwrap();
+            if let Some(table_caps) = table_re.captures(after_from) {
+                let table = table_caps.get(0).map(|m| m.as_str().replace(['"', '`'], ""));
+                return table.map(|t| format!("SELECT {}", t));
+            }
+        }
     }
     if let Some(caps) = insert_re.captures(sql) {
-        let table = caps.get(1).map(|m| m.as_str().replace(['"', '`'], ""));
+        let table = caps.get(2).map(|m| m.as_str().replace(['"', '`'], ""));
         return table.map(|t| format!("INSERT {}", t));
     }
     if let Some(caps) = update_re.captures(sql) {
-        let table = caps.get(1).map(|m| m.as_str().replace(['"', '`'], ""));
+        let table = caps.get(2).map(|m| m.as_str().replace(['"', '`'], ""));
         return table.map(|t| format!("UPDATE {}", t));
     }
     if let Some(caps) = delete_re.captures(sql) {
-        let table = caps.get(1).map(|m| m.as_str().replace(['"', '`'], ""));
+        let table = caps.get(2).map(|m| m.as_str().replace(['"', '`'], ""));
         return table.map(|t| format!("DELETE {}", t));
     }
-
     None
 }
 
@@ -71,4 +81,79 @@ pub fn start_and_activate_span(
     let ctx = Context::current_with_span(span);
     let guard = ctx.attach();
     store_guard(exec_data, guard);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_select() {
+        let sql = "SELECT * FROM users";
+        assert_eq!(extract_span_name_from_sql(sql), Some("SELECT users".to_string()));
+    }
+
+    #[test]
+    fn test_insert() {
+        let sql = "INSERT INTO products VALUES (1, 'foo')";
+        assert_eq!(extract_span_name_from_sql(sql), Some("INSERT products".to_string()));
+    }
+
+    #[test]
+    fn test_update() {
+        let sql = "UPDATE orders SET status = 'shipped'";
+        assert_eq!(extract_span_name_from_sql(sql), Some("UPDATE orders".to_string()));
+    }
+
+    #[test]
+    fn test_delete() {
+        let sql = "DELETE FROM sessions WHERE id = 1";
+        assert_eq!(extract_span_name_from_sql(sql), Some("DELETE sessions".to_string()));
+    }
+
+    #[test]
+    fn test_quotes_and_case() {
+        let sql = "select * from `MyTable`";
+        assert_eq!(extract_span_name_from_sql(sql), Some("SELECT MyTable".to_string()));
+        let sql = "INSERT INTO \"OtherTable\"";
+        assert_eq!(extract_span_name_from_sql(sql), Some("INSERT OtherTable".to_string()));
+    }
+
+    #[test]
+    fn test_no_match() {
+        let sql = "DROP TABLE users";
+        assert_eq!(extract_span_name_from_sql(sql), None);
+    }
+
+    #[test]
+    fn test_leading_whitespace() {
+        let sql = "   SELECT * FROM   users   ";
+        assert_eq!(extract_span_name_from_sql(sql), Some("SELECT users".to_string()));
+    }
+
+    #[test]
+    fn test_multiline_select() {
+        let sql = "SELECT\n  *\nFROM\n  users";
+        assert_eq!(extract_span_name_from_sql(sql), Some("SELECT users".to_string()));
+    }
+
+    #[test]
+    fn test_select_distinct() {
+        let sql = "select count(distinct(first_name)) * FROM users";
+        assert_eq!(extract_span_name_from_sql(sql), Some("SELECT users".to_string()));
+    }
+
+    #[test]
+    fn test_select_with_subquery_in_from() {
+        let sql = "SELECT * FROM (SELECT * FROM users) AS sub";
+        // Should not match the subquery, but the outer FROM (which is a subquery, so None)
+        assert_eq!(extract_span_name_from_sql(sql), None);
+    }
+
+    #[test]
+    fn test_select_with_subquery_in_where() {
+        let sql = "SELECT * FROM users WHERE id IN (SELECT id FROM orders)";
+        // Should match the outer table 'users'
+        assert_eq!(extract_span_name_from_sql(sql), Some("SELECT users".to_string()));
+    }
 }

--- a/otel/tests/auto/laminas/laminas-db-connect-pdo.phpt
+++ b/otel/tests/auto/laminas/laminas-db-connect-pdo.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Test laminas db connect
+--EXTENSIONS--
+otel
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 70100 || PHP_VERSION_ID >= 80300) {
+    die('skip requires PHP 7.1 -> 8.2');
+}
+?>
+--ENV--
+OTEL_TRACES_EXPORTER=memory
+OTEL_SPAN_PROCESSOR=simple
+--INI--
+otel.log.level="warn"
+otel.log.file="/dev/stdout"
+otel.cli.enabled=1
+--FILE--
+<?php
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Laminas\Db\Adapter\Adapter;
+use OpenTelemetry\API\Trace\SpanExporter\Memory;
+
+$adapter = new Adapter([
+    'driver'   => 'pdo',
+    'dsn'      => 'sqlite:' . __DIR__ . '/data/test.sqlite',
+]);
+$connection = $adapter->getDriver()->getConnection()->connect();
+
+var_dump(Memory::count());
+$connect = Memory::getSpans()[0];
+var_dump($connect['attributes']);
+?>
+--EXPECTF--
+int(1)
+array(%d) {
+%A
+  ["db.system.name"]=>
+  string(6) "sqlite"
+}


### PR DESCRIPTION
This pull request improves the OpenTelemetry auto-instrumentation for Laminas DB connections and SQL span naming, with a focus on more accurate database attribute extraction and better SQL operation labeling. It also adds comprehensive tests for SQL span name extraction and introduces a new PHPT integration test for Laminas DB connections.

**Laminas DB instrumentation improvements:**

* Added `extract_laminas_db_namespace` to extract the database namespace from multiple possible keys in connection parameters, improving detection of the database name (`laminas.rs`).
* Enhanced driver-to-semantic-convention mapping in `map_laminas_driver_to_semconv`, including parsing the DSN for generic `pdo` drivers and supporting more drivers like `pdo_dblib` (`laminas.rs`).
* Improved attribute extraction in `pre_callback` to use the new namespace extraction and updated driver mapping, ensuring more accurate span attributes (`laminas.rs`).
* Changed the default span name for unknown SQL operations from `"OTHER"` to `"execute"` for better clarity (`laminas.rs`).

**SQL span name extraction and testing:**

* Refined SQL regex patterns in `extract_span_name_from_sql` to better handle multiline queries, quoted identifiers, and subqueries, returning `"SELECT"` when the table can't be determined (`utils.rs`).
* Added a comprehensive set of unit tests for SQL span name extraction, covering various SQL forms and edge cases (`utils.rs`).

**Testing and CI:**

* Added a new PHPT test for Laminas DB connection via PDO to verify correct span attribute extraction (`laminas-db-connect-pdo.phpt`).
* Ensured Rust tests are run as part of the Makefile's `test` target (`Makefile`).