### PR TITLE
Add logs signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ _Only works for PHP versions supported by PIE (8.1+)_
 
 `php pie.phar install brettmc/otel-php-rust:<version>`
 
-### PECL
-
-todo
-
 ### Manual
 
 ```shell
@@ -142,6 +138,8 @@ auto-instrumentation plugins for some legacy frameworks.
 
 ### Manual instrumentation
 
+#### Tracing
+
 Basic usage:
 ```php
 $provider = \OpenTelemetry\API\Globals::tracerProvider();
@@ -168,6 +166,34 @@ $scope = $root->activate();
 $root->end();
 $scope->detach();
 ```
+
+## Logs
+```php
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\LogRecord;
+
+$logger = Globals::loggerProvider()->getLogger("my_logger", '0.1');
+$record = new LogRecord('hello otel');
+$record
+    ->setSeverityNumber(9) //info
+    ->setSeverityText('Info')
+    ->setEventName('my_event')
+    ->setTimestamp((int) (microtime(true) * 1e9))
+    ->setAttributes([
+        'a_bool' => true,
+        'an_int' => 1,
+        'a_float' => 1.1,
+        'a_string' => 'foo',
+        'string_array' => ['one', 'two', 'three'],
+        'int_array' => [1, 2, 3],
+        'float_array' => [1.1, 2.2, 3.3],
+        'bool_array' => [true, false, true],
+    ]);
+$logger->emit($record);
+```
+
+Note that if there is an active span when the log record is emitted, the span context
+will be associated with the log record.
 
 ## Plugins
 

--- a/otel/src/class_registry.rs
+++ b/otel/src/class_registry.rs
@@ -31,6 +31,7 @@ use crate::{
         log_record::make_log_record_class,
         logger_provider::make_logger_provider_class,
         logger_provider_interface::make_logger_provider_interface,
+        memory_exporter::make_logs_memory_exporter_class,
     },
 };
 
@@ -60,6 +61,7 @@ pub fn register_classes_and_interfaces(module: &mut Module) {
     let context_class = module.add_class(context_class_entity);
     let _storage_class = module.add_class(storage_class_entity);
     let _in_memory_exporter_class = module.add_class(make_memory_exporter_class());
+    let _logs_memory_exporter_class = module.add_class(make_logs_memory_exporter_class());
 
     let span_class = module.add_class(make_span_class(scope_class.clone(), span_context_class.clone(), context_class.clone(), &span_interface));
     let non_recording_span_class = module.add_class(make_non_recording_span_class(scope_class.clone(), span_context_class.clone(), context_class.clone(), &span_interface));

--- a/otel/src/class_registry.rs
+++ b/otel/src/class_registry.rs
@@ -19,14 +19,19 @@ use crate::{
         status_code::make_status_code_interface,
         tracer::make_tracer_class,
         tracer_interface::make_tracer_interface,
-        tracer_provider::{
-            make_tracer_provider_class,
-        },
+        tracer_provider::make_tracer_provider_class,
         tracer_provider_interface::make_tracer_provider_interface,
         span_context::make_span_context_class,
         propagation::trace_context_propagator::make_trace_context_propagator_class,
     },
     globals::make_globals_class,
+    logs::{
+        logger_interface::make_logger_interface,
+        logger::make_logger_class,
+        log_record::make_log_record_class,
+        logger_provider::make_logger_provider_class,
+        logger_provider_interface::make_logger_provider_interface,
+    },
 };
 
 pub fn register_classes_and_interfaces(module: &mut Module) {
@@ -40,6 +45,8 @@ pub fn register_classes_and_interfaces(module: &mut Module) {
     let span_interface = module.add_interface(make_span_interface());
 
     // co-dependent classes
+    let logger_interface = module.add_interface(make_logger_interface());
+    let logger_provider_interface = module.add_interface(make_logger_provider_interface());
     let mut scope_class_entity = new_scope_class();
     let mut context_class_entity = new_context_class();
     let mut storage_class_entity = new_storage_class();
@@ -61,6 +68,10 @@ pub fn register_classes_and_interfaces(module: &mut Module) {
 
     let tracer_class = module.add_class(make_tracer_class(span_builder_class.clone(), tracer_interface));
     let tracer_provider_class = module.add_class(make_tracer_provider_class(tracer_class.clone(), tracer_provider_interface));
-    let _globals_class = module.add_class(make_globals_class(tracer_provider_class.clone(), trace_context_propagator_class.clone()));
+    let logger_class = module.add_class(make_logger_class(logger_interface));
+    let logger_provider_class = module.add_class(make_logger_provider_class(logger_class.clone(), logger_provider_interface.clone()));
+    let _globals_class = module.add_class(make_globals_class(tracer_provider_class.clone(), trace_context_propagator_class.clone(), logger_provider_class.clone()));
     let _status_code_interface = module.add_interface(make_status_code_interface());
+
+    let _log_record_class = module.add_class(make_log_record_class());
 }

--- a/otel/src/globals.rs
+++ b/otel/src/globals.rs
@@ -6,15 +6,19 @@ use phper::{
     functions::ReturnType,
     types::ReturnTypeHint,
 };
-use crate::trace::{
-    propagation::trace_context_propagator::TraceContextPropagatorClass,
-    tracer_provider::TracerProviderClass,
+use crate::{
+    logs::logger_provider::LoggerProviderClass,
+    trace::{
+        propagation::trace_context_propagator::TraceContextPropagatorClass,
+        tracer_provider::TracerProviderClass,
+    }
 };
 const GLOBALS_CLASS_NAME: &str = r"OpenTelemetry\API\Globals";
 
 pub fn make_globals_class(
     tracer_provider_class: TracerProviderClass,
     propagator_class: TraceContextPropagatorClass,
+    logger_provider_class: LoggerProviderClass,
 ) -> ClassEntity<()> {
     let mut class = ClassEntity::new(GLOBALS_CLASS_NAME);
 
@@ -30,6 +34,13 @@ pub fn make_globals_class(
             let object = propagator_class.init_object()?;
             Ok::<_, phper::Error>(object)
         }); //TODO return interface
+
+    class
+        .add_static_method("loggerProvider", Visibility::Public, move |_| {
+            let object = logger_provider_class.init_object()?;
+            Ok::<_, phper::Error>(object)
+        })
+        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(String::from(r"OpenTelemetry\API\Logs\LoggerProvider"))));
 
     class
 }

--- a/otel/src/lib.rs
+++ b/otel/src/lib.rs
@@ -12,6 +12,7 @@ pub mod error;
 pub mod globals;
 pub mod request;
 pub mod logging;
+pub mod logs;
 pub mod util;
 pub mod module;
 pub mod auto;

--- a/otel/src/lib.rs
+++ b/otel/src/lib.rs
@@ -13,6 +13,7 @@ pub mod globals;
 pub mod request;
 pub mod logging;
 pub mod logs;
+pub mod runtime;
 pub mod util;
 pub mod module;
 pub mod auto;

--- a/otel/src/logs/log_record.rs
+++ b/otel/src/logs/log_record.rs
@@ -1,0 +1,94 @@
+use phper::classes::ClassEntity;
+use opentelemetry::logs::{Severity, AnyValue};
+use phper::{
+    alloc::ToRefOwned,
+    classes::{StateClass, Visibility},
+};
+
+pub const LOG_RECORD_CLASS_NAME: &str = r"OpenTelemetry\API\Logs\LogRecord";
+
+// State holds the values to be set on the builder later
+#[derive(Default)]
+pub struct LogRecordState {
+    pub body: Option<AnyValue>,
+    pub severity: Option<Severity>,
+}
+
+pub type LogRecordClass = StateClass<LogRecordState>;
+
+pub fn make_log_record_class() -> ClassEntity<LogRecordState> {
+    let mut class =
+        ClassEntity::<LogRecordState>::new_with_default_state_constructor(LOG_RECORD_CLASS_NAME);
+
+    class
+        .add_method("__construct", Visibility::Public, |this, arguments| {
+            //if argument 1 (body) is provided, set it
+            if let Some(body_zval) = arguments.get(0) {
+                let body_str = body_zval.expect_z_str()?;
+                if !body_str.is_empty() {
+                    // Convert to owned String immediately to avoid lifetime issues
+                    let body_any = AnyValue::String(body_str.to_str()?.to_owned().into());
+                    this.as_mut_state().body = Some(body_any);
+                }
+            }
+            Ok::<_, phper::Error>(())
+        })
+        .argument(phper::functions::Argument::new("body").optional().with_default_value("").with_type_hint(phper::types::ArgumentTypeHint::String));
+
+    class.add_method("setSeverityNumber", Visibility::Public, |this, arguments| {
+        let severity = arguments[0].expect_long()? as u8;
+        let sev = match severity {
+            1 => Severity::Trace,
+            2 => Severity::Trace2,
+            3 => Severity::Trace3,
+            4 => Severity::Trace4,
+            5 => Severity::Debug,
+            6 => Severity::Debug2,
+            7 => Severity::Debug3,
+            8 => Severity::Debug4,
+            9 => Severity::Info,
+            10 => Severity::Info2,
+            11 => Severity::Info3,
+            12 => Severity::Info4,
+            13 => Severity::Warn,
+            14 => Severity::Warn2,
+            15 => Severity::Warn3,
+            16 => Severity::Warn4,
+            17 => Severity::Error,
+            18 => Severity::Error2,
+            19 => Severity::Error3,
+            20 => Severity::Error4,
+            21 => Severity::Fatal,
+            22 => Severity::Fatal2,
+            23 => Severity::Fatal3,
+            24 => Severity::Fatal4,
+            _ => Severity::Info,
+        };
+        this.as_mut_state().severity = Some(sev);
+        Ok::<_, phper::Error>(this.to_ref_owned())
+    })
+    .argument(phper::functions::Argument::new("severityNumber"));
+
+    class.add_method("setBody", Visibility::Public, |this, arguments| {
+        let body_zval = &arguments[0];
+        let body_any = if let Ok(s) = body_zval.expect_z_str() {
+            // Convert to owned String immediately to avoid lifetime issues
+            AnyValue::String(s.to_str()?.to_owned().into())
+        } else if let Ok(i) = body_zval.expect_long() {
+            AnyValue::Int(i)
+        } else if let Ok(f) = body_zval.expect_double() {
+            AnyValue::Double(f)
+        } else if let Ok(b) = body_zval.expect_bool() {
+            AnyValue::Boolean(b)
+        } else {
+            // fallback: string representation using Debug
+            let s = format!("{:?}", body_zval);
+            AnyValue::String(s.into())
+        };
+        this.as_mut_state().body = Some(body_any);
+        Ok::<_, phper::Error>(this.to_ref_owned())
+    })
+    .argument(phper::functions::Argument::new("body"));
+
+    class
+}

--- a/otel/src/logs/log_record.rs
+++ b/otel/src/logs/log_record.rs
@@ -1,13 +1,18 @@
 use phper::classes::ClassEntity;
 use opentelemetry::{
     KeyValue,
-    logs::{Severity, AnyValue}
+    logs::{Severity, AnyValue},
+    trace::{TraceId, SpanId, TraceFlags},
+    Context,
+    trace::TraceContextExt,
 };
 use phper::{
     alloc::ToRefOwned,
     classes::{StateClass, Visibility},
     functions::Argument,
+    types::ArgumentTypeHint,
 };
+use std::time::SystemTime;
 
 pub const LOG_RECORD_CLASS_NAME: &str = r"OpenTelemetry\API\Logs\LogRecord";
 
@@ -18,9 +23,38 @@ pub struct LogRecordState {
     pub severity: Option<Severity>,
     pub severity_text: Option<String>,
     pub attributes: Vec<KeyValue>,
+    pub event_name: Option<String>,
+    pub timestamp: Option<SystemTime>,
+    pub trace_id: Option<TraceId>,
+    pub span_id: Option<SpanId>,
+    pub trace_flags: Option<TraceFlags>,
 }
 
 pub type LogRecordClass = StateClass<LogRecordState>;
+
+fn insert_attribute(state: &mut LogRecordState, key: String, value_zval: &phper::values::ZVal) -> Result<(), phper::Error> {
+    let any_value = if let Ok(s) = value_zval.expect_z_str() {
+        AnyValue::String(s.to_str()?.to_owned().into())
+    } else if let Ok(i) = value_zval.expect_long() {
+        AnyValue::Int(i)
+    } else if let Ok(f) = value_zval.expect_double() {
+        AnyValue::Double(f)
+    } else if let Ok(b) = value_zval.expect_bool() {
+        AnyValue::Boolean(b)
+    } else {
+        AnyValue::String(format!("{:?}", value_zval).into())
+    };
+    // Convert AnyValue to opentelemetry::Value
+    let value = match any_value {
+        AnyValue::String(s) => opentelemetry::Value::String(s),
+        AnyValue::Int(i) => opentelemetry::Value::I64(i),
+        AnyValue::Double(f) => opentelemetry::Value::F64(f),
+        AnyValue::Boolean(b) => opentelemetry::Value::Bool(b),
+        _ => todo!(),
+    };
+    state.attributes.push(KeyValue::new(key, value));
+    Ok(())
+}
 
 pub fn make_log_record_class() -> ClassEntity<LogRecordState> {
     let mut class =
@@ -37,9 +71,32 @@ pub fn make_log_record_class() -> ClassEntity<LogRecordState> {
                     this.as_mut_state().body = Some(body_any);
                 }
             }
+            // Set trace context from current OpenTelemetry context if available
+            let ctx = Context::current();
+            let span = ctx.span();
+            let span_ctx = span.span_context();
+            if span_ctx.is_valid() {
+                this.as_mut_state().trace_id = Some(span_ctx.trace_id());
+                this.as_mut_state().span_id = Some(span_ctx.span_id());
+                this.as_mut_state().trace_flags = Some(span_ctx.trace_flags());
+            }
             Ok::<_, phper::Error>(())
         })
         .argument(phper::functions::Argument::new("body").optional().with_default_value("").with_type_hint(phper::types::ArgumentTypeHint::String));
+
+    class
+        .add_method("setTimestamp", Visibility::Public, |this, arguments| {
+            // Accept nanoseconds since UNIX_EPOCH as int
+            let ts_zval = &arguments[0];
+            let nanos: u64 = ts_zval.expect_long()? as u64;
+            let system_time = std::time::UNIX_EPOCH
+                + std::time::Duration::from_secs(nanos / 1_000_000_000)
+                + std::time::Duration::from_nanos(nanos % 1_000_000_000);
+            tracing::debug!("Setting LogRecord timestamp to {:?}", system_time);
+            this.as_mut_state().timestamp = Some(system_time);
+            Ok::<_, phper::Error>(this.to_ref_owned())
+        })
+        .argument(phper::functions::Argument::new("timestamp").with_type_hint(ArgumentTypeHint::Int));
 
     class
         .add_method("setSeverityNumber", Visibility::Public, |this, arguments| {
@@ -74,7 +131,7 @@ pub fn make_log_record_class() -> ClassEntity<LogRecordState> {
             this.as_mut_state().severity = Some(sev);
             Ok::<_, phper::Error>(this.to_ref_owned())
         })
-        .argument(phper::functions::Argument::new("severityNumber"));
+        .argument(phper::functions::Argument::new("severityNumber").with_type_hint(ArgumentTypeHint::Int));
 
     class
         .add_method("setBody", Visibility::Public, |this, arguments| {
@@ -112,36 +169,36 @@ pub fn make_log_record_class() -> ClassEntity<LogRecordState> {
             let state = this.as_mut_state();
             let key = arguments[0].expect_z_str()?.to_str()?.to_string();
             let value_zval = &arguments[1];
-
-            let any_value = if let Ok(s) = value_zval.expect_z_str() {
-                AnyValue::String(s.to_str()?.to_owned().into())
-            } else if let Ok(i) = value_zval.expect_long() {
-                AnyValue::Int(i)
-            } else if let Ok(f) = value_zval.expect_double() {
-                AnyValue::Double(f)
-            } else if let Ok(b) = value_zval.expect_bool() {
-                AnyValue::Boolean(b)
-            } else {
-                // fallback: string representation using Debug
-                AnyValue::String(format!("{:?}", value_zval).into())
-            };
-
-            // Convert AnyValue to opentelemetry::Value
-            let value = match any_value {
-                AnyValue::String(s) => opentelemetry::Value::String(s),
-                AnyValue::Int(i) => opentelemetry::Value::I64(i),
-                AnyValue::Double(f) => opentelemetry::Value::F64(f),
-                AnyValue::Boolean(b) => opentelemetry::Value::Bool(b),
-                // Add more variants if needed
-                _ => todo!(),
-            };
-
-            state.attributes.push(KeyValue::new(key, value));
-
+            insert_attribute(state, key, value_zval)?;
             Ok::<_, phper::Error>(this.to_ref_owned())
         })
         .argument(Argument::new("key"))
         .argument(Argument::new("value").optional());
+
+    class
+        .add_method("setAttributes", Visibility::Public, |this, arguments| {
+            let state = this.as_mut_state();
+            let attrs_zval = &arguments[0];
+            let attrs_arr = attrs_zval.expect_z_arr()?;
+            for (k, v) in attrs_arr.iter() {
+                // Support both string and integer keys
+                let key = match k {
+                    phper::arrays::IterKey::ZStr(zs) => zs.to_str()?.to_string(),
+                    phper::arrays::IterKey::Index(i) => i.to_string(),
+                };
+                insert_attribute(state, key, v)?;
+            }
+            Ok::<_, phper::Error>(this.to_ref_owned())
+        })
+        .argument(Argument::new("attributes"));
+
+    class
+        .add_method("setEventName", Visibility::Public, |this, arguments| {
+            let name = arguments[0].expect_z_str()?.to_str()?.to_owned();
+            this.as_mut_state().event_name = Some(name);
+            Ok::<_, phper::Error>(this.to_ref_owned())
+        })
+        .argument(phper::functions::Argument::new("eventName"));
 
     class
 }

--- a/otel/src/logs/log_record.rs
+++ b/otel/src/logs/log_record.rs
@@ -1,8 +1,12 @@
 use phper::classes::ClassEntity;
-use opentelemetry::logs::{Severity, AnyValue};
+use opentelemetry::{
+    KeyValue,
+    logs::{Severity, AnyValue}
+};
 use phper::{
     alloc::ToRefOwned,
     classes::{StateClass, Visibility},
+    functions::Argument,
 };
 
 pub const LOG_RECORD_CLASS_NAME: &str = r"OpenTelemetry\API\Logs\LogRecord";
@@ -12,6 +16,8 @@ pub const LOG_RECORD_CLASS_NAME: &str = r"OpenTelemetry\API\Logs\LogRecord";
 pub struct LogRecordState {
     pub body: Option<AnyValue>,
     pub severity: Option<Severity>,
+    pub severity_text: Option<String>,
+    pub attributes: Vec<KeyValue>,
 }
 
 pub type LogRecordClass = StateClass<LogRecordState>;
@@ -35,60 +41,107 @@ pub fn make_log_record_class() -> ClassEntity<LogRecordState> {
         })
         .argument(phper::functions::Argument::new("body").optional().with_default_value("").with_type_hint(phper::types::ArgumentTypeHint::String));
 
-    class.add_method("setSeverityNumber", Visibility::Public, |this, arguments| {
-        let severity = arguments[0].expect_long()? as u8;
-        let sev = match severity {
-            1 => Severity::Trace,
-            2 => Severity::Trace2,
-            3 => Severity::Trace3,
-            4 => Severity::Trace4,
-            5 => Severity::Debug,
-            6 => Severity::Debug2,
-            7 => Severity::Debug3,
-            8 => Severity::Debug4,
-            9 => Severity::Info,
-            10 => Severity::Info2,
-            11 => Severity::Info3,
-            12 => Severity::Info4,
-            13 => Severity::Warn,
-            14 => Severity::Warn2,
-            15 => Severity::Warn3,
-            16 => Severity::Warn4,
-            17 => Severity::Error,
-            18 => Severity::Error2,
-            19 => Severity::Error3,
-            20 => Severity::Error4,
-            21 => Severity::Fatal,
-            22 => Severity::Fatal2,
-            23 => Severity::Fatal3,
-            24 => Severity::Fatal4,
-            _ => Severity::Info,
-        };
-        this.as_mut_state().severity = Some(sev);
-        Ok::<_, phper::Error>(this.to_ref_owned())
-    })
-    .argument(phper::functions::Argument::new("severityNumber"));
+    class
+        .add_method("setSeverityNumber", Visibility::Public, |this, arguments| {
+            let severity = arguments[0].expect_long()? as u8;
+            let sev = match severity {
+                1 => Severity::Trace,
+                2 => Severity::Trace2,
+                3 => Severity::Trace3,
+                4 => Severity::Trace4,
+                5 => Severity::Debug,
+                6 => Severity::Debug2,
+                7 => Severity::Debug3,
+                8 => Severity::Debug4,
+                9 => Severity::Info,
+                10 => Severity::Info2,
+                11 => Severity::Info3,
+                12 => Severity::Info4,
+                13 => Severity::Warn,
+                14 => Severity::Warn2,
+                15 => Severity::Warn3,
+                16 => Severity::Warn4,
+                17 => Severity::Error,
+                18 => Severity::Error2,
+                19 => Severity::Error3,
+                20 => Severity::Error4,
+                21 => Severity::Fatal,
+                22 => Severity::Fatal2,
+                23 => Severity::Fatal3,
+                24 => Severity::Fatal4,
+                _ => Severity::Info,
+            };
+            this.as_mut_state().severity = Some(sev);
+            Ok::<_, phper::Error>(this.to_ref_owned())
+        })
+        .argument(phper::functions::Argument::new("severityNumber"));
 
-    class.add_method("setBody", Visibility::Public, |this, arguments| {
-        let body_zval = &arguments[0];
-        let body_any = if let Ok(s) = body_zval.expect_z_str() {
-            // Convert to owned String immediately to avoid lifetime issues
-            AnyValue::String(s.to_str()?.to_owned().into())
-        } else if let Ok(i) = body_zval.expect_long() {
-            AnyValue::Int(i)
-        } else if let Ok(f) = body_zval.expect_double() {
-            AnyValue::Double(f)
-        } else if let Ok(b) = body_zval.expect_bool() {
-            AnyValue::Boolean(b)
-        } else {
-            // fallback: string representation using Debug
-            let s = format!("{:?}", body_zval);
-            AnyValue::String(s.into())
-        };
-        this.as_mut_state().body = Some(body_any);
-        Ok::<_, phper::Error>(this.to_ref_owned())
-    })
-    .argument(phper::functions::Argument::new("body"));
+    class
+        .add_method("setBody", Visibility::Public, |this, arguments| {
+            let body_zval = &arguments[0];
+            let body_any = if let Ok(s) = body_zval.expect_z_str() {
+                // Convert to owned String immediately to avoid lifetime issues
+                AnyValue::String(s.to_str()?.to_owned().into())
+            } else if let Ok(i) = body_zval.expect_long() {
+                AnyValue::Int(i)
+            } else if let Ok(f) = body_zval.expect_double() {
+                AnyValue::Double(f)
+            } else if let Ok(b) = body_zval.expect_bool() {
+                AnyValue::Boolean(b)
+            } else {
+                // fallback: string representation using Debug
+                let s = format!("{:?}", body_zval);
+                AnyValue::String(s.into())
+            };
+            this.as_mut_state().body = Some(body_any);
+            Ok::<_, phper::Error>(this.to_ref_owned())
+        })
+        .argument(phper::functions::Argument::new("body"));
+
+    class
+        .add_method("setSeverityText", Visibility::Public, |this, arguments| {
+            let text = arguments[0].expect_z_str()?.to_str()?.to_owned();
+            this.as_mut_state().severity_text = Some(text);
+
+            Ok::<_, phper::Error>(this.to_ref_owned())
+        })
+        .argument(phper::functions::Argument::new("severityText"));
+
+    class
+        .add_method("setAttribute", Visibility::Public, |this, arguments| {
+            let state = this.as_mut_state();
+            let key = arguments[0].expect_z_str()?.to_str()?.to_string();
+            let value_zval = &arguments[1];
+
+            let any_value = if let Ok(s) = value_zval.expect_z_str() {
+                AnyValue::String(s.to_str()?.to_owned().into())
+            } else if let Ok(i) = value_zval.expect_long() {
+                AnyValue::Int(i)
+            } else if let Ok(f) = value_zval.expect_double() {
+                AnyValue::Double(f)
+            } else if let Ok(b) = value_zval.expect_bool() {
+                AnyValue::Boolean(b)
+            } else {
+                // fallback: string representation using Debug
+                AnyValue::String(format!("{:?}", value_zval).into())
+            };
+
+            // Convert AnyValue to opentelemetry::Value
+            let value = match any_value {
+                AnyValue::String(s) => opentelemetry::Value::String(s),
+                AnyValue::Int(i) => opentelemetry::Value::I64(i),
+                AnyValue::Double(f) => opentelemetry::Value::F64(f),
+                AnyValue::Boolean(b) => opentelemetry::Value::Bool(b),
+                // Add more variants if needed
+                _ => todo!(),
+            };
+
+            state.attributes.push(KeyValue::new(key, value));
+
+            Ok::<_, phper::Error>(this.to_ref_owned())
+        })
+        .argument(Argument::new("key"))
+        .argument(Argument::new("value").optional());
 
     class
 }

--- a/otel/src/logs/logger.rs
+++ b/otel/src/logs/logger.rs
@@ -47,6 +47,26 @@ pub fn make_logger_class(
             if let Some(ref body) = record_state.body {
                 log_record.set_body(body.clone());
             }
+            if let Some(ref severity_text) = record_state.severity_text {
+                // Avoid passing a reference to a value tied to the closure's lifetime.
+                // Clone to a String, then get a &'static str via Box leak (safe for log record lifetime).
+                let static_str: &'static str = Box::leak(severity_text.clone().into_boxed_str());
+                log_record.set_severity_text(static_str);
+            }
+            if !record_state.attributes.is_empty() {
+                for attr in &record_state.attributes {
+                    // attr.value is opentelemetry::Value, but add_attribute expects AnyValue
+                    let any_value = match &attr.value {
+                        opentelemetry::Value::String(s) => opentelemetry::logs::AnyValue::String(s.clone()),
+                        opentelemetry::Value::Bool(b) => opentelemetry::logs::AnyValue::Boolean(*b),
+                        opentelemetry::Value::I64(i) => opentelemetry::logs::AnyValue::Int(*i),
+                        opentelemetry::Value::F64(f) => opentelemetry::logs::AnyValue::Double(*f),
+                        // Add more variants if needed
+                        _ => opentelemetry::logs::AnyValue::String(format!("{:?}", attr.value).into()),
+                    };
+                    log_record.add_attribute(attr.key.clone(), any_value);
+                }
+            }
             tracing::debug!("Built LogRecord: {:?}", log_record);
 
             logger.emit(log_record);

--- a/otel/src/logs/logger.rs
+++ b/otel/src/logs/logger.rs
@@ -1,0 +1,60 @@
+use phper::{
+    classes::{ClassEntity, Interface, StateClass, Visibility},
+    functions::{Argument, ReturnType},
+    types::{ArgumentTypeHint, ReturnTypeHint},
+};
+use std::convert::Infallible;
+use opentelemetry::logs::{
+    Logger,
+    LogRecord,
+};
+use opentelemetry_sdk::logs::SdkLogger;
+use crate::logs::log_record::{LOG_RECORD_CLASS_NAME, LogRecordState};
+
+pub type LoggerClass = StateClass<Option<SdkLogger>>;
+
+const LOGGER_CLASS_NAME: &str = r"OpenTelemetry\API\Logs\Logger";
+
+pub fn make_logger_class(
+    logger_interface: Interface,
+) -> ClassEntity<Option<SdkLogger>> {
+    let mut class =
+        ClassEntity::<Option<SdkLogger>>::new_with_default_state_constructor(LOGGER_CLASS_NAME);
+
+    class.implements(logger_interface);
+    class.add_method("__construct", Visibility::Private, |_, _| {
+        Ok::<_, Infallible>(())
+    });
+
+    class
+        .add_method("emit", Visibility::Public, |this, arguments| {
+            tracing::debug!("Logger::emit called");
+            // Get the logger
+            let logger: &SdkLogger = this.as_state().as_ref().unwrap();
+
+            // Get the LogRecordClass object from PHP
+            let record_zval = &arguments[0];
+            let record_obj = record_zval.expect_z_obj();
+            // SAFETY: Only safe if the object is a LogRecordClass (guaranteed by PHP type hint)
+            let record_state = unsafe { record_obj?.as_state_obj::<LogRecordState>().as_state() };
+
+            // Build the log record using the logger's builder
+            let mut log_record = logger.create_log_record();
+
+            if let Some(severity) = record_state.severity {
+                log_record.set_severity_number(severity);
+            }
+            if let Some(ref body) = record_state.body {
+                log_record.set_body(body.clone());
+            }
+            tracing::debug!("Built LogRecord: {:?}", log_record);
+
+            logger.emit(log_record);
+
+            Ok::<_, phper::Error>(())
+        })
+        .argument(Argument::new("record").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(LOG_RECORD_CLASS_NAME))))
+        .return_type(ReturnType::new(ReturnTypeHint::Void));
+
+    class
+}

--- a/otel/src/logs/logger.rs
+++ b/otel/src/logs/logger.rs
@@ -48,10 +48,12 @@ pub fn make_logger_class(
                 log_record.set_body(body.clone());
             }
             if let Some(ref severity_text) = record_state.severity_text {
+                //TODO avoid leaking memory here (Cow<'static, str>)
                 let static_str: &'static str = Box::leak(severity_text.clone().into_boxed_str());
                 log_record.set_severity_text(static_str);
             }
             if let Some(ref event_name) = record_state.event_name {
+                //TODO avoid leaking memory here (Cow<'static, str>)
                 let static_str: &'static str = Box::leak(event_name.clone().into_boxed_str());
                 log_record.set_event_name(static_str);
             }

--- a/otel/src/logs/logger_interface.rs
+++ b/otel/src/logs/logger_interface.rs
@@ -1,0 +1,18 @@
+use phper::{
+    classes::{InterfaceEntity},
+    functions::{Argument, ReturnType},
+    types::{ArgumentTypeHint, ReturnTypeHint},
+};
+use crate::logs::log_record::LOG_RECORD_CLASS_NAME;
+
+pub fn make_logger_interface() -> InterfaceEntity {
+    let mut interface = InterfaceEntity::new(r"OpenTelemetry\API\Logs\LoggerInterface");
+
+    interface
+        .add_method("emit")
+        .argument(Argument::new("record").with_type_hint(ArgumentTypeHint::ClassEntry(String::from(LOG_RECORD_CLASS_NAME))))
+        .return_type(ReturnType::new(ReturnTypeHint::Void))
+    ;
+
+    interface
+}

--- a/otel/src/logs/logger_provider.rs
+++ b/otel/src/logs/logger_provider.rs
@@ -1,0 +1,251 @@
+use phper::{
+    classes::{ClassEntity, StateClass, Visibility},
+    functions::{Argument, ReturnType},
+    types::{ArgumentTypeHint, ReturnTypeHint},
+};
+use std::{
+    collections::HashMap,
+    convert::Infallible,
+    env,
+    process,
+    sync::{Arc, Mutex},
+};
+use opentelemetry::{
+    logs::LoggerProvider,
+    KeyValue,
+    InstrumentationScope,
+};
+use opentelemetry_stdout::LogExporter as StdoutLogExporter;
+use opentelemetry_sdk::{
+    logs::{
+        SimpleLogProcessor, InMemoryLogExporter,
+        BatchConfigBuilder,
+        BatchLogProcessor,
+        SdkLoggerProvider,
+    },
+    Resource,
+};
+use once_cell::sync::{Lazy, OnceCell};
+use tokio::runtime::Runtime;
+use crate::{
+    logs::logger::LoggerClass,
+    request,
+    util,
+};
+use opentelemetry_otlp::{
+    Protocol,
+    LogExporter as OtlpLogExporter,
+    WithExportConfig,
+};
+
+pub const LOGGER_PROVIDER_CLASS_NAME: &str = r"OpenTelemetry\API\Logs\LoggerProvider";
+
+pub type LoggerProviderClass = StateClass<()>;
+
+static TOKIO_RUNTIME: OnceCell<Runtime> = OnceCell::new();
+static LOGGER_PROVIDERS: Lazy<Mutex<HashMap<(u32, String), Arc<SdkLoggerProvider>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static NOOP_LOGGER_PROVIDER: Lazy<Arc<SdkLoggerProvider>> = Lazy::new(|| {
+    Arc::new(SdkLoggerProvider::builder()
+        .with_resource(Resource::builder_empty().build())
+        .build())
+});
+
+fn get_logger_provider_key() -> (u32, String) {
+    let pid = process::id();
+    let service_name = env::var("OTEL_SERVICE_NAME").unwrap_or_default();
+    let resource_attrs = env::var("OTEL_RESOURCE_ATTRIBUTES").unwrap_or_default();
+    let key = format!("{}:{}", service_name, resource_attrs);
+    (pid, key)
+}
+
+pub fn init_once() {
+    let key = get_logger_provider_key();
+    let mut providers = LOGGER_PROVIDERS.lock().unwrap();
+    if providers.contains_key(&key) {
+        tracing::debug!("logger provider already exists for key {:?}", key);
+        return;
+    }
+    tracing::debug!("creating logger provider for key {:?}", key);
+
+    let resource = Resource::builder()
+        .with_attribute(KeyValue::new("telemetry.sdk.language", "php"))
+        .with_attribute(KeyValue::new("telemetry.sdk.name", "ext-otel"))
+        .with_attribute(KeyValue::new("telemetry.sdk.version", env!("CARGO_PKG_VERSION")))
+        .with_attribute(KeyValue::new("process.runtime.name", util::get_sapi_module_name()))
+        .with_attribute(KeyValue::new("process.runtime.version", util::get_php_version()))
+        .with_attribute(KeyValue::new("process.pid", process::id().to_string()))
+        .with_attribute(KeyValue::new("host.name", hostname::get().unwrap_or_default().to_string_lossy().to_string()))
+        .build();
+
+    let mut builder = SdkLoggerProvider::builder().with_resource(resource);
+
+    let exporter_type = env::var("OTEL_LOGS_EXPORTER").unwrap_or_else(|_| "otlp".to_string());
+    let use_simple = env::var("OTEL_BLRP_TYPE").as_deref() == Ok("simple");
+
+    if exporter_type == "none" {
+        tracing::debug!("Using no-op log exporter");
+        // No exporter, just build the provider
+    } else if exporter_type == "console" {
+        tracing::debug!("Using Console log exporter");
+        let exporter = StdoutLogExporter::default();
+        if use_simple {
+            builder = builder.with_log_processor(SimpleLogProcessor::new(exporter));
+        } else {
+            let batch_config = BatchConfigBuilder::default().build();
+            let batch = BatchLogProcessor::builder(exporter)
+                .with_batch_config(batch_config)
+                .build();
+            builder = builder.with_log_processor(batch);
+        }
+    } else if exporter_type == "memory" {
+        tracing::debug!("Using in-memory log exporter");
+        let exporter = InMemoryLogExporter::default();
+        if use_simple {
+            builder = builder.with_log_processor(SimpleLogProcessor::new(exporter));
+        } else {
+            let batch_config = BatchConfigBuilder::default().build();
+            let batch = BatchLogProcessor::builder(exporter)
+                .with_batch_config(batch_config)
+                .build();
+            builder = builder.with_log_processor(batch);
+        }
+    } else {
+        // Default to OTLP exporter
+        if env::var("OTEL_EXPORTER_OTLP_PROTOCOL").as_deref() == Ok("http/protobuf") {
+            tracing::debug!("Using http/protobuf log exporter");
+            let exporter = OtlpLogExporter::builder()
+                .with_http()
+                .with_protocol(Protocol::HttpBinary)
+                .build()
+                .expect("Failed to create OTLP http log exporter");
+            if use_simple {
+                builder = builder.with_log_processor(SimpleLogProcessor::new(exporter));
+            } else {
+                let batch_config = BatchConfigBuilder::default().build();
+                let batch = BatchLogProcessor::builder(exporter)
+                    .with_batch_config(batch_config)
+                    .build();
+                builder = builder.with_log_processor(batch);
+            }
+        } else {
+            tracing::debug!("Using gRPC log exporter with tokio runtime");
+            if TOKIO_RUNTIME.get().is_none() {
+                tracing::debug!("Creating tokio runtime");
+                let runtime = Runtime::new().expect("Failed to create Tokio runtime required for gRPC export");
+                TOKIO_RUNTIME.set(runtime).expect("Tokio runtime already set");
+                tracing::debug!("tokio runtime initialized");
+            }
+            let runtime = TOKIO_RUNTIME.get().expect("Tokio runtime not initialized");
+            let exporter = runtime.block_on(async {
+                OtlpLogExporter::builder()
+                    .with_tonic()
+                    .build()
+                    .expect("Failed to create OTLP grpc log exporter")
+            });
+            if use_simple {
+                builder = builder.with_log_processor(SimpleLogProcessor::new(exporter));
+            } else {
+                let batch_config = BatchConfigBuilder::default().build();
+                let batch = BatchLogProcessor::builder(exporter)
+                    .with_batch_config(batch_config)
+                    .build();
+                builder = builder.with_log_processor(batch);
+            }
+        }
+    }
+
+    let provider = Arc::new(builder.build());
+    providers.insert(key, provider.clone());
+}
+
+pub fn get_logger_provider() -> Arc<SdkLoggerProvider> {
+    if request::is_disabled() {
+        tracing::debug!("OpenTelemetry is disabled for this request, returning no-op logger provider");
+        return NOOP_LOGGER_PROVIDER.clone();
+    }
+    let providers = LOGGER_PROVIDERS.lock().unwrap();
+    let key = get_logger_provider_key();
+    if let Some(provider) = providers.get(&key) {
+        return provider.clone();
+    } else {
+        tracing::warn!("no logger provider initialized for key {:?}, using no-op", key);
+        NOOP_LOGGER_PROVIDER.clone()
+    }
+}
+
+pub fn shutdown() {
+    let pid = process::id();
+    let mut providers = LOGGER_PROVIDERS.lock().unwrap();
+    let keys_to_remove: Vec<_> = providers
+        .keys()
+        .filter(|(k_pid, _)| *k_pid == pid)
+        .cloned()
+        .collect();
+    if !keys_to_remove.is_empty() {
+        tracing::info!("Shutting down all LoggerProviders for pid {}", pid);
+        for key in keys_to_remove {
+            tracing::debug!("Shutting down LoggerProvider for key {:?}", key);
+            providers.remove(&key);
+        }
+    } else {
+        tracing::info!("no logger providers to shutdown for pid {}", pid);
+    }
+}
+
+pub fn make_logger_provider_class(
+    logger_class: LoggerClass,
+    logger_provider_interface: phper::classes::Interface,
+) -> ClassEntity<()> {
+    let mut class =
+        ClassEntity::<()>::new_with_default_state_constructor(LOGGER_PROVIDER_CLASS_NAME);
+
+    class.implements(logger_provider_interface);
+    class.add_method("__construct", Visibility::Private, |_, _| {
+        Ok::<_, Infallible>(())
+    });
+
+    class
+        .add_method("getLogger", Visibility::Public, move |_this, arguments| {
+            let provider = get_logger_provider();
+            let name = arguments[0].expect_z_str()?.to_str()?.to_string();
+
+            let version = arguments.get(1)
+                .and_then(|arg| arg.as_z_str())
+                .map(|s| s.to_str().ok().map(|s| s.to_string()))
+                .flatten();
+
+            let schema_url = arguments.get(2)
+                .and_then(|arg| arg.as_z_str())
+                .map(|s| s.to_str().ok().map(|s| s.to_string()))
+                .flatten();
+
+            let attributes = arguments.get(3)
+                .and_then(|arg| arg.as_z_arr())
+                .map(|zarr| zarr.to_owned());
+
+            let mut scope_builder = InstrumentationScope::builder(name);
+            if let Some(version) = version {
+                scope_builder = scope_builder.with_version(version);
+            }
+            if let Some(schema_url) = schema_url {
+                scope_builder = scope_builder.with_schema_url(schema_url);
+            }
+            if let Some(attributes) = attributes {
+                scope_builder = scope_builder.with_attributes(util::zval_arr_to_key_value_vec(attributes));
+            }
+            let scope = scope_builder.build();
+
+            let logger = provider.logger_with_scope(scope);
+            let mut object = logger_class.init_object()?;
+            *object.as_mut_state() = Some(logger);
+
+            Ok::<_, phper::Error>(object)
+        })
+        .argument(Argument::new("name").with_type_hint(ArgumentTypeHint::String))
+        .argument(Argument::new("version").optional().with_type_hint(ArgumentTypeHint::String).allow_null())
+        .argument(Argument::new("schemaUrl").optional().with_type_hint(ArgumentTypeHint::String).allow_null())
+        .argument(Argument::new("attributes").with_type_hint(ArgumentTypeHint::ClassEntry(String::from("Iterable"))).with_default_value("[]"))
+        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(String::from(r"OpenTelemetry\API\Logs\LoggerInterface"))));
+
+    class
+}

--- a/otel/src/logs/logger_provider_interface.rs
+++ b/otel/src/logs/logger_provider_interface.rs
@@ -1,0 +1,18 @@
+use phper::{
+    classes::{InterfaceEntity},
+    functions::{Argument, ReturnType},
+    types::{ArgumentTypeHint, ReturnTypeHint},
+};
+
+pub fn make_logger_provider_interface() -> InterfaceEntity {
+    let mut interface = InterfaceEntity::new(r"OpenTelemetry\API\Logs\LoggerProviderInterface");
+    interface
+        .add_method("getLogger")
+        .argument(Argument::new("name").with_type_hint(ArgumentTypeHint::String))
+        .argument(Argument::new("version").optional().with_type_hint(ArgumentTypeHint::String).allow_null())
+        .argument(Argument::new("schemaUrl").optional().with_type_hint(ArgumentTypeHint::String).allow_null())
+        .argument(Argument::new("attributes").with_type_hint(ArgumentTypeHint::ClassEntry(String::from("Iterable"))).with_default_value("[]"))
+        .return_type(ReturnType::new(ReturnTypeHint::ClassEntry(String::from(r"OpenTelemetry\API\Logs\LoggerInterface"))));
+
+    interface
+}

--- a/otel/src/logs/memory_exporter.rs
+++ b/otel/src/logs/memory_exporter.rs
@@ -1,0 +1,101 @@
+use phper::{
+    classes::{ClassEntity, StateClass, Visibility},
+};
+use phper::functions::ReturnType;
+use phper::types::ReturnTypeHint;
+use phper::arrays::ZArray;
+use std::sync::Mutex;
+use std::convert::Infallible;
+use once_cell::sync::Lazy;
+use opentelemetry_sdk::logs::InMemoryLogExporter;
+
+pub type MemoryExporterClass = StateClass<()>;
+
+const MEMORY_EXPORTER_CLASS_NAME: &str = r"OpenTelemetry\API\Logs\MemoryLogsExporter";
+
+// Static instance of the exporter
+pub static MEMORY_EXPORTER: Lazy<Mutex<InMemoryLogExporter>> = Lazy::new(|| {
+    Mutex::new(InMemoryLogExporter::default())
+});
+
+pub fn make_logs_memory_exporter_class() -> ClassEntity<()> {
+    let mut class = ClassEntity::<()>::new(MEMORY_EXPORTER_CLASS_NAME);
+
+    class.add_method("__construct", Visibility::Private, |_, _| {
+        Ok::<_, Infallible>(())
+    });
+
+    class.add_static_method("count", Visibility::Public, |_| {
+        let exporter = MEMORY_EXPORTER.lock().unwrap();
+        let logs_count = exporter.get_emitted_logs().map(|logs| logs.len()).unwrap_or(0);
+        Ok::<_, Infallible>(logs_count as i64)
+    })
+        .return_type(ReturnType::new(ReturnTypeHint::Int));
+
+    class.add_static_method("getLogs", Visibility::Public, |_| {
+        let mut result = ZArray::new();
+        let exporter = MEMORY_EXPORTER.lock().unwrap();
+        let logs = exporter.get_emitted_logs().unwrap_or_default();
+        for (_i, log) in logs.iter().enumerate() {
+            let mut arr = ZArray::new();
+            // Log body
+            arr.insert("body", format!("{:?}", log.record.body()));
+            // Severity number
+            let severity_number = log.record.severity_number().map(|s| s as i64).unwrap_or(0);
+            arr.insert("severity_number", severity_number);
+            // Severity text
+            let severity_text = log.record.severity_text().unwrap_or("");
+            arr.insert("severity_text", severity_text);
+            // Timestamp
+            let timestamp = log
+                .record
+                .timestamp()
+                .and_then(|ts| ts.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_micros() as i64)
+                .unwrap_or(0);
+            arr.insert("timestamp", timestamp);
+            // Observed timestamp
+            let observed_timestamp = log
+                .record
+                .observed_timestamp()
+                .and_then(|ts| ts.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_micros() as i64);
+            if let Some(ts) = observed_timestamp {
+                arr.insert("observed_timestamp", ts);
+            }
+            // Attributes
+            let mut attributes = ZArray::new();
+            // for kv in log.record.attributes.iter() {
+            //     attributes.insert(kv.key.as_str(), format!("{:?}", kv.value));
+            // }
+            arr.insert("attributes", attributes);
+            // Instrumentation scope
+            let mut scope = ZArray::new();
+            scope.insert("name", log.instrumentation.name());
+            scope.insert("version", log.instrumentation.version().as_deref().unwrap_or(""));
+            scope.insert("schema_url", log.instrumentation.schema_url().as_deref().unwrap_or(""));
+            arr.insert("instrumentation_scope", scope);
+            // Resource (sorted by key)
+            let mut resource = ZArray::new();
+            let mut resource_kv: Vec<_> = log.resource.iter().collect();
+            resource_kv.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+            for (k, v) in resource_kv {
+                resource.insert(k.as_str(), format!("{:?}", v));
+            }
+            arr.insert("resource", resource);
+            result.insert((), arr);
+
+        }
+        Ok::<_, Infallible>(result)
+    })
+        .return_type(ReturnType::new(ReturnTypeHint::Array));
+
+    class.add_static_method("reset", Visibility::Public, |_| {
+        let exporter = MEMORY_EXPORTER.lock().unwrap();
+        exporter.reset();
+        Ok::<_, Infallible>(())
+    })
+        .return_type(ReturnType::new(ReturnTypeHint::Void));
+
+    class
+}

--- a/otel/src/logs/memory_exporter.rs
+++ b/otel/src/logs/memory_exporter.rs
@@ -65,15 +65,22 @@ pub fn make_logs_memory_exporter_class() -> ClassEntity<()> {
             }
             // Attributes
             let mut attributes = ZArray::new();
-            // for kv in log.record.attributes.iter() {
-            //     attributes.insert(kv.key.as_str(), format!("{:?}", kv.value));
-            // }
+            for (key, value) in log.record.attributes_iter() {
+                attributes.insert(key.as_str(), format!("{:?}", value));
+            }
             arr.insert("attributes", attributes);
             // Instrumentation scope
             let mut scope = ZArray::new();
             scope.insert("name", log.instrumentation.name());
             scope.insert("version", log.instrumentation.version().as_deref().unwrap_or(""));
             scope.insert("schema_url", log.instrumentation.schema_url().as_deref().unwrap_or(""));
+            // Scope attributes
+            let mut scope_attributes = ZArray::new();
+            for kv in log.instrumentation.attributes() {
+                scope_attributes.insert(kv.key.as_str(), format!("{:?}", kv.value));
+            }
+            scope.insert("attributes", scope_attributes);
+
             arr.insert("instrumentation_scope", scope);
             // Resource (sorted by key)
             let mut resource = ZArray::new();

--- a/otel/src/logs/mod.rs
+++ b/otel/src/logs/mod.rs
@@ -1,0 +1,6 @@
+pub mod logger_interface;
+pub mod logger;
+pub mod log_record;
+pub mod logger_provider;
+pub mod logger_provider_interface;
+

--- a/otel/src/logs/mod.rs
+++ b/otel/src/logs/mod.rs
@@ -3,4 +3,5 @@ pub mod logger;
 pub mod log_record;
 pub mod logger_provider;
 pub mod logger_provider_interface;
+pub mod memory_exporter;
 

--- a/otel/src/module.rs
+++ b/otel/src/module.rs
@@ -1,6 +1,7 @@
 use crate::{
     config,
     logging,
+    logs::logger_provider,
     util::get_sapi_module_name,
     auto,
     trace::tracer_provider,
@@ -48,6 +49,7 @@ pub fn on_module_shutdown() {
     }
     tracing::debug!("OpenTelemetry::MSHUTDOWN");
     tracer_provider::shutdown();
+    logger_provider::shutdown();
 }
 
 pub fn is_disabled() -> bool {

--- a/otel/src/request.rs
+++ b/otel/src/request.rs
@@ -32,6 +32,7 @@ use crate::{
     config,
     context::storage,
     logging,
+    logs::logger_provider,
     module,
     error::php_error_to_attributes,
     trace::{local_root_span, tracer_provider},
@@ -61,6 +62,7 @@ pub fn on_request_init() {
     }
 
     tracer_provider::init_once();
+    logger_provider::init_once();
     global::set_text_map_propagator(TraceContextPropagator::new());
 
     init();

--- a/otel/src/runtime.rs
+++ b/otel/src/runtime.rs
@@ -1,0 +1,12 @@
+use once_cell::sync::OnceCell;
+use tokio::runtime::Runtime;
+
+static TOKIO_RUNTIME: OnceCell<Runtime> = OnceCell::new();
+
+pub fn init_tokio_runtime() -> &'static Runtime {
+    if TOKIO_RUNTIME.get().is_none() {
+        let runtime = Runtime::new().expect("Failed to create Tokio runtime required for gRPC export");
+        TOKIO_RUNTIME.set(runtime).expect("Tokio runtime already set");
+    }
+    TOKIO_RUNTIME.get().expect("Tokio runtime not initialized")
+}

--- a/otel/tests/otlp/export_log_grpc.phpt
+++ b/otel/tests/otlp/export_log_grpc.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Export a log: http/protobuf
+--EXTENSIONS--
+otel
+--INI--
+otel.cli.enabled=On
+otel.log.level="error"
+otel.log.file="/dev/stdout"
+--ENV--
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_EXPORTER_OTLP_TIMEOUT=1500
+OTEL_SERVICE_NAME=test-grpc
+--FILE--
+<?php
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\LogRecord;
+
+$logger = Globals::loggerProvider()->getLogger("my_logger", '0.1', 'schema.url', ['one' => 1]);
+$record = new LogRecord('test');
+$record->setSeverityNumber(9); //info
+$logger->emit($record);
+
+var_dump('done');
+?>
+--EXPECT--
+string(4) "done"

--- a/otel/tests/otlp/export_log_grpc.phpt
+++ b/otel/tests/otlp/export_log_grpc.phpt
@@ -18,7 +18,18 @@ use OpenTelemetry\API\Logs\LogRecord;
 
 $logger = Globals::loggerProvider()->getLogger("my_logger", '0.1', 'schema.url', ['one' => 1]);
 $record = new LogRecord('test');
-$record->setSeverityNumber(9); //info
+$record
+    ->setSeverityNumber(9) //info
+    ->setSeverityText('Info')
+    ->setEventName('my_event')
+    ->setTimestamp((int)(microtime(true) * 1e9))
+    ->setAttributes([
+        'a_bool' => true,
+        'an_int' => 1,
+        'a_float' => 1.1,
+        'a_string' => 'foo',
+    ])
+    ->setAttribute('another_string', 'bar');
 $logger->emit($record);
 
 var_dump('done');

--- a/otel/tests/otlp/export_log_grpc.phpt
+++ b/otel/tests/otlp/export_log_grpc.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Export a log: http/protobuf
+Export a log: grpc
 --EXTENSIONS--
 otel
 --INI--

--- a/otel/tests/otlp/export_log_grpc.phpt
+++ b/otel/tests/otlp/export_log_grpc.phpt
@@ -28,6 +28,10 @@ $record
         'an_int' => 1,
         'a_float' => 1.1,
         'a_string' => 'foo',
+        'string_array' => ['one', 'two', 'three'],
+        'int_array' => [1, 2, 3],
+        'float_array' => [1.1, 2.2, 3.3],
+        'bool_array' => [true, false, true],
     ])
     ->setAttribute('another_string', 'bar');
 $logger->emit($record);

--- a/otel/tests/otlp/export_log_http_protobuf.phpt
+++ b/otel/tests/otlp/export_log_http_protobuf.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Export a log: http/protobuf
+--EXTENSIONS--
+otel
+--INI--
+otel.cli.enabled=On
+otel.log.level="error"
+otel.log.file="/dev/stdout"
+--ENV--
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_TIMEOUT=1500
+OTEL_SERVICE_NAME=test-http-protobuf
+--FILE--
+<?php
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\LogRecord;
+
+$logger = Globals::loggerProvider()->getLogger("my_logger", '0.1', 'schema.url', ['one' => 1]);
+$record = new LogRecord('test');
+$record->setSeverityNumber(9); //info
+$logger->emit($record);
+
+var_dump('done');
+?>
+--EXPECT--
+string(4) "done"

--- a/otel/tests/phpt/context/context-activate.phpt
+++ b/otel/tests/phpt/context/context-activate.phpt
@@ -4,6 +4,8 @@ Activate context
 otel
 --ENV--
 OTEL_TRACES_EXPORTER=none
+OTEL_LOGS_EXPORTER=none
+OTEL_METRICS_EXPORTER=none
 --FILE--
 <?php
 use OpenTelemetry\Context\Context;

--- a/otel/tests/phpt/context/context-cleanup-span.phpt
+++ b/otel/tests/phpt/context/context-cleanup-span.phpt
@@ -4,6 +4,8 @@ Internal context storage empty after use
 otel
 --ENV--
 OTEL_TRACES_EXPORTER=memory
+OTEL_LOGS_EXPORTER=none
+OTEL_METRICS_EXPORTER=none
 --INI--
 otel.log.level=debug
 otel.log.file="/dev/stdout"

--- a/otel/tests/phpt/context/context-cleanup.phpt
+++ b/otel/tests/phpt/context/context-cleanup.phpt
@@ -4,6 +4,8 @@ Activate context
 otel
 --ENV--
 OTEL_TRACES_EXPORTER=none
+OTEL_LOGS_EXPORTER=none
+OTEL_METRICS_EXPORTER=none
 --INI--
 otel.log.level=debug
 otel.log.file="/dev/stdout"

--- a/otel/tests/phpt/context/context-get-current.phpt
+++ b/otel/tests/phpt/context/context-get-current.phpt
@@ -4,6 +4,8 @@ Get current context
 otel
 --ENV--
 OTEL_TRACES_EXPORTER=none
+OTEL_LOGS_EXPORTER=none
+OTEL_METRICS_EXPORTER=none
 --FILE--
 <?php
 use OpenTelemetry\Context\Context;

--- a/otel/tests/phpt/context/context-get-from-scope.phpt
+++ b/otel/tests/phpt/context/context-get-from-scope.phpt
@@ -4,6 +4,8 @@ Get context from scope
 otel
 --ENV--
 OTEL_TRACES_EXPORTER=none
+OTEL_LOGS_EXPORTER=none
+OTEL_METRICS_EXPORTER=none
 --FILE--
 <?php
 use OpenTelemetry\Context\Context;

--- a/otel/tests/phpt/context/context-set-get.phpt
+++ b/otel/tests/phpt/context/context-set-get.phpt
@@ -7,6 +7,8 @@ Set and retrieve a value from context
 otel
 --ENV--
 OTEL_TRACES_EXPORTER=none
+OTEL_LOGS_EXPORTER=none
+OTEL_METRICS_EXPORTER=none
 --FILE--
 <?php
 use OpenTelemetry\Context\Context;

--- a/otel/tests/phpt/globals.phpt
+++ b/otel/tests/phpt/globals.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test fetching providers from Globals
+--EXTENSIONS--
+otel
+--ENV--
+OTEL_TRACES_EXPORTER=memory
+OTEL_LOGS_EXPORTER=memory
+OTEL_SPAN_PROCESSOR=simple
+OTEL_SPAN_PROCESSOR=simple
+--INI--
+otel.cli.enabled=1
+--FILE--
+<?php
+use OpenTelemetry\API\Globals;
+
+$tracerProvider = Globals::tracerProvider();
+var_dump(get_class($tracerProvider));
+$loggerProvider = Globals::loggerProvider();
+var_dump(get_class($loggerProvider));
+?>
+--EXPECT--
+string(38) "OpenTelemetry\API\Trace\TracerProvider"
+string(37) "OpenTelemetry\API\Logs\LoggerProvider"

--- a/otel/tests/phpt/logs/logger/emit-log-record.phpt
+++ b/otel/tests/phpt/logs/logger/emit-log-record.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Emit a log record from a logger
+--EXTENSIONS--
+otel
+--ENV--
+OTEL_TRACES_EXPORTER=none
+OTEL_LOGS_EXPORTER=console
+--INI--
+otel.log.level=warn
+otel.cli.enabled=1
+--FILE--
+<?php
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\LogRecord;
+
+$logger = Globals::loggerProvider()->getLogger("my_logger", '0.1', 'schema.url', ['one' => 1]);
+$record = new LogRecord('test');
+$record->setSeverityNumber(9); //info
+$logger->emit($record);
+?>
+--EXPECTF--
+array(2){
+  ["body"]=>
+  string(4) "test"
+  ["severity_text"]=>
+  string(9) "INFO"
+}

--- a/otel/tests/phpt/logs/logger/emit-log-record.phpt
+++ b/otel/tests/phpt/logs/logger/emit-log-record.phpt
@@ -18,6 +18,12 @@ use OpenTelemetry\API\Logs\MemoryLogsExporter;
 $logger = Globals::loggerProvider()->getLogger("my_logger", '0.1', 'schema.url', ['one' => 1]);
 $record = new LogRecord('test');
 $record->setSeverityNumber(9); //info
+$record
+    ->setSeverityText('Info')
+    ->setAttribute('a_bool', true)
+    ->setAttribute('an_int', 1)
+    ->setAttribute('a_float', 1.1)
+    ->setAttribute('a_string', 'string');
 $logger->emit($record);
 var_dump(MemoryLogsExporter::count());
 $exported = MemoryLogsExporter::getLogs()[0];
@@ -31,22 +37,35 @@ array(8) {
   ["severity_number"]=>
   int(9)
   ["severity_text"]=>
-  string(0) ""
+  string(4) "Info"
   ["timestamp"]=>
   int(0)
   ["observed_timestamp"]=>
   int(%d)
   ["attributes"]=>
-  array(0) {
+  array(4) {
+    ["a_bool"]=>
+    string(13) "Boolean(true)"
+    ["an_int"]=>
+    string(6) "Int(1)"
+    ["a_float"]=>
+    string(11) "Double(1.1)"
+    ["a_string"]=>
+    string(23) "String(Owned("string"))"
   }
   ["instrumentation_scope"]=>
-  array(3) {
+  array(4) {
     ["name"]=>
     string(9) "my_logger"
     ["version"]=>
     string(3) "0.1"
     ["schema_url"]=>
     string(10) "schema.url"
+    ["attributes"]=>
+    array(1) {
+      ["one"]=>
+      string(6) "I64(1)"
+    }
   }
   ["resource"]=>
   array(8) {

--- a/otel/tests/phpt/logs/logger/emit-log-record.phpt
+++ b/otel/tests/phpt/logs/logger/emit-log-record.phpt
@@ -4,7 +4,8 @@ Emit a log record from a logger
 otel
 --ENV--
 OTEL_TRACES_EXPORTER=none
-OTEL_LOGS_EXPORTER=console
+OTEL_LOGS_PROCESSOR=simple
+OTEL_LOGS_EXPORTER=memory
 --INI--
 otel.log.level=warn
 otel.cli.enabled=1
@@ -12,16 +13,58 @@ otel.cli.enabled=1
 <?php
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Logs\LogRecord;
+use OpenTelemetry\API\Logs\MemoryLogsExporter;
 
 $logger = Globals::loggerProvider()->getLogger("my_logger", '0.1', 'schema.url', ['one' => 1]);
 $record = new LogRecord('test');
 $record->setSeverityNumber(9); //info
 $logger->emit($record);
+var_dump(MemoryLogsExporter::count());
+$exported = MemoryLogsExporter::getLogs()[0];
+var_dump($exported);
 ?>
 --EXPECTF--
-array(2){
+int(1)
+array(8) {
   ["body"]=>
-  string(4) "test"
+  string(27) "Some(String(Owned("test")))"
+  ["severity_number"]=>
+  int(9)
   ["severity_text"]=>
-  string(9) "INFO"
+  string(0) ""
+  ["timestamp"]=>
+  int(0)
+  ["observed_timestamp"]=>
+  int(%d)
+  ["attributes"]=>
+  array(0) {
+  }
+  ["instrumentation_scope"]=>
+  array(3) {
+    ["name"]=>
+    string(9) "my_logger"
+    ["version"]=>
+    string(3) "0.1"
+    ["schema_url"]=>
+    string(10) "schema.url"
+  }
+  ["resource"]=>
+  array(8) {
+    ["host.name"]=>
+    string(29) "String(Owned("%s"))"
+    ["process.pid"]=>
+    string(22) "String(Owned("%d"))"
+    ["process.runtime.name"]=>
+    string(20) "String(Owned("cli"))"
+    ["process.runtime.version"]=>
+    string(23) "String(Owned("%d.%d.%d"))"
+    ["service.name"]=>
+    string(33) "String(Static("unknown_service"))"
+    ["telemetry.sdk.language"]=>
+    string(21) "String(Static("php"))"
+    ["telemetry.sdk.name"]=>
+    string(26) "String(Static("ext-otel"))"
+    ["telemetry.sdk.version"]=>
+    string(24) "String(Static("%d.%d.%d"))"
+  }
 }

--- a/otel/tests/phpt/logs/logger/emit-log-record.phpt
+++ b/otel/tests/phpt/logs/logger/emit-log-record.phpt
@@ -35,6 +35,10 @@ $record
         'an_int' => 1,
         'a_float' => 1.1,
         'a_string' => 'foo',
+        'string_array' => ['one', 'two', 'three'],
+        'int_array' => [1, 2, 3],
+        'float_array' => [1.1, 2.2, 3.3],
+        'bool_array' => [true, false, true],
     ])
     ->setAttribute('another_string', 'bar');
 $logger->emit($record);
@@ -69,7 +73,7 @@ array(12) {
   ["observed_timestamp"]=>
   string(%d) "%d-%d-%dT%s"
   ["attributes"]=>
-  array(5) {
+  array(9) {
     ["a_bool"]=>
     string(13) "Boolean(true)"
     ["an_int"]=>
@@ -78,6 +82,14 @@ array(12) {
     string(11) "Double(1.1)"
     ["a_string"]=>
     string(20) "String(Owned("foo"))"
+    ["string_array"]=>
+    string(82) "String(Owned("Array(String([Owned(\"one\"), Owned(\"two\"), Owned(\"three\")]))"))"
+    ["int_array"]=>
+    string(38) "String(Owned("Array(I64([1, 2, 3]))"))"
+    ["float_array"]=>
+    string(44) "String(Owned("Array(F64([1.1, 2.2, 3.3]))"))"
+    ["bool_array"]=>
+    string(49) "String(Owned("Array(Bool([true, false, true]))"))"
     ["another_string"]=>
     string(20) "String(Owned("bar"))"
   }

--- a/otel/tests/phpt/logs/logger/get-logger.phpt
+++ b/otel/tests/phpt/logs/logger/get-logger.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Get logger from logger provider
+--EXTENSIONS--
+otel
+--FILE--
+<?php
+use OpenTelemetry\API\Globals;
+
+var_dump(Globals::loggerProvider()->getLogger("my_tracer", '0.1', 'schema.url'));
+var_dump(Globals::loggerProvider()->getLogger("my_tracer", '0.1'));
+var_dump(Globals::loggerProvider()->getLogger("my_tracer"));
+var_dump(Globals::loggerProvider()->getLogger("my_tracer", '0.1', 'schema.url', ['one' => 1]));
+?>
+--EXPECTF--
+object(OpenTelemetry\API\Logs\Logger)#%d (0) {
+}
+object(OpenTelemetry\API\Logs\Logger)#%d (0) {
+}
+object(OpenTelemetry\API\Logs\Logger)#%d (0) {
+}
+object(OpenTelemetry\API\Logs\Logger)#%d (0) {
+}

--- a/otel/tests/phpt/logs/logger/get-with-instrumentation-scope.phpt
+++ b/otel/tests/phpt/logs/logger/get-with-instrumentation-scope.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Get a logger with instrumentation scope
+--EXTENSIONS--
+otel
+--INI--
+otel.cli.enabled=1
+--ENV--
+OTEL_LOGS_EXPORTER=console
+OTEL_LOGS_PROCESSOR=simple
+--FILE--
+<?php
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Logs\LogRecord;
+
+$logger = Globals::loggerProvider()->getLogger('test', '1.0', 'https://schemas.opentelemetry.io/1.30.0', ['a_string' => 'foo', 'a_bool' => true, 'a_int' => 3]);
+$record = new LogRecord();
+$logger->emit($record);
+//todo get record back from exporter and verify instrumentation scope
+?>
+--EXPECT--
+array(4) {
+  ["name"]=>
+  string(4) "test"
+  ["version"]=>
+  string(3) "1.0"
+  ["schema_url"]=>
+  string(39) "https://schemas.opentelemetry.io/1.30.0"
+  ["attributes"]=>
+  array(3) {
+    ["a_string"]=>
+    string(3) "foo"
+    ["a_bool"]=>
+    bool(true)
+    ["a_int"]=>
+    int(3)
+  }
+}

--- a/otel/tests/phpt/logs/logger/get-with-instrumentation-scope.phpt
+++ b/otel/tests/phpt/logs/logger/get-with-instrumentation-scope.phpt
@@ -5,33 +5,37 @@ otel
 --INI--
 otel.cli.enabled=1
 --ENV--
-OTEL_LOGS_EXPORTER=console
+OTEL_TRACES_EXPORTER=none
 OTEL_LOGS_PROCESSOR=simple
+OTEL_LOGS_EXPORTER=memory
 --FILE--
 <?php
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Logs\LogRecord;
+use OpenTelemetry\API\Logs\MemoryLogsExporter;
 
 $logger = Globals::loggerProvider()->getLogger('test', '1.0', 'https://schemas.opentelemetry.io/1.30.0', ['a_string' => 'foo', 'a_bool' => true, 'a_int' => 3]);
 $record = new LogRecord();
 $logger->emit($record);
-//todo get record back from exporter and verify instrumentation scope
+$exported = MemoryLogsExporter::getLogs()[0];
+$scope = $exported['instrumentation_scope'];
+var_dump($scope);
 ?>
---EXPECT--
+--EXPECTF--
 array(4) {
   ["name"]=>
   string(4) "test"
   ["version"]=>
   string(3) "1.0"
   ["schema_url"]=>
-  string(39) "https://schemas.opentelemetry.io/1.30.0"
+  string(%d) "https://schemas.opentelemetry.io/1.%d.%d"
   ["attributes"]=>
   array(3) {
     ["a_string"]=>
-    string(3) "foo"
+    string(20) "String(Owned("foo"))"
     ["a_bool"]=>
-    bool(true)
+    string(10) "Bool(true)"
     ["a_int"]=>
-    int(3)
+    string(6) "I64(3)"
   }
 }

--- a/otel/tests/phpt/request/request-auto-cli-cleanup.phpt
+++ b/otel/tests/phpt/request/request-auto-cli-cleanup.phpt
@@ -4,6 +4,8 @@ Force auto root span for CLI, check context is empty when finished
 otel
 --ENV--
 OTEL_TRACES_EXPORTER=none
+OTEL_LOGS_EXPORTER=none
+OTEL_METRICS_EXPORTER=none
 --INI--
 otel.log.level="trace"
 otel.log.file="/dev/stdout"


### PR DESCRIPTION
This pull request introduces initial support for OpenTelemetry Logs into the codebase, adding new classes and interfaces for log records, loggers, and logger providers. It also updates the global OpenTelemetry API to expose logging functionality, and registers all new logging-related classes and interfaces with the module system.

**OpenTelemetry Logs Integration:**

* Added new modules and classes for logs, including `LogRecord`, `Logger`, `LoggerProvider`, and their interfaces, enabling structured log creation and emission in the OpenTelemetry API. [[1]](diffhunk://#diff-284fca3723666f5224086f0d11681cf5de6e886abd4dc6f4b870cbd3024981eeR15-R16) [[2]](diffhunk://#diff-34054707d2d25e9ab85c50d3721352644441fc999eb9eef801205a61b3ab973aR1-R204) [[3]](diffhunk://#diff-dc35becf9f354a7ad33955aa3fa4c2244a24cce2e04b5fb3512197b450fdcd0dR1-R90) [[4]](diffhunk://#diff-d321d8ef85c409722851d96228ee0b517a6fc3e2dd2bfdd60b97cff9f3b48a87R1-R18)

**Global API Enhancements:**

* Updated the `Globals` class to provide access to the logger provider, making it possible to retrieve a logger provider via the OpenTelemetry global API. [[1]](diffhunk://#diff-5b8611369a1e7c8985046c0b9a6cf916fc4ee5d387dfeddbe14912d5bee963e0L9-R21) [[2]](diffhunk://#diff-5b8611369a1e7c8985046c0b9a6cf916fc4ee5d387dfeddbe14912d5bee963e0R38-R44)

**Module Registration:**

* Registered all new logging-related classes and interfaces (including log record, logger, logger provider, and memory exporter) in the module's class registry, ensuring they are available to PHP code. [[1]](diffhunk://#diff-9862502ab3cfa16d05e186009b6339b254ca0e49e0306a119511281955188934L22-R35) [[2]](diffhunk://#diff-9862502ab3cfa16d05e186009b6339b254ca0e49e0306a119511281955188934R49-R50) [[3]](diffhunk://#diff-9862502ab3cfa16d05e186009b6339b254ca0e49e0306a119511281955188934R64) [[4]](diffhunk://#diff-9862502ab3cfa16d05e186009b6339b254ca0e49e0306a119511281955188934L64-R78)